### PR TITLE
ci: add CodeQL workflow for PR analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,37 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 7 * * 0'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [actions]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary
- Adds CodeQL analysis workflow that runs on pull requests targeting main
- Satisfies the code_scanning ruleset requirement
- Unblocks PR #15 (Renovate configuration) and future PRs

## Changes
- New workflow file: `.github/workflows/codeql.yml`
- Triggers: push to main, PRs to main, weekly schedule
- Analyzes GitHub Actions workflow files for security issues

## Test plan
- [ ] CodeQL workflow runs on this PR
- [ ] After merging, PR #15 can pass required checks

Generated with Claude Code