### PR TITLE
chore(.github): add pre-commit hooks and quality enforcement configs

### DIFF
--- a/.commitlintrc.yaml
+++ b/.commitlintrc.yaml
@@ -21,6 +21,7 @@ rules:
       - test
       - refactor
       - perf
+      - breaking
   type-case:
     - 2
     - always
@@ -36,10 +37,6 @@ rules:
     - lower-case
 
   # --- Subject ---
-  subject-case:
-    - 2
-    - always
-    - lower-case
   subject-empty:
     - 2
     - never
@@ -58,7 +55,7 @@ rules:
   body-max-line-length:
     - 1
     - always
-    - 200
+    - 100
   body-leading-blank:
     - 2
     - always

--- a/.commitlintrc.yaml
+++ b/.commitlintrc.yaml
@@ -2,6 +2,7 @@
 # Commitlint Configuration
 # =============================================================================
 # Enforces conventional commit message format.
+# Only overrides that differ from @commitlint/config-conventional defaults.
 # Reference: https://commitlint.js.org/
 # =============================================================================
 
@@ -9,7 +10,7 @@ extends:
   - "@commitlint/config-conventional"
 
 rules:
-  # --- Type ---
+  # Custom type list matching CONTRIBUTING.md (adds breaking, removes build/revert/style)
   type-enum:
     - 2
     - always
@@ -22,47 +23,19 @@ rules:
       - refactor
       - perf
       - breaking
-  type-case:
+
+  # Promote leading-blank rules from warning (default) to error
+  body-leading-blank:
     - 2
     - always
-    - lower-case
-  type-empty:
-    - 2
-    - never
-
-  # --- Scope ---
-  scope-case:
+  footer-leading-blank:
     - 2
     - always
-    - lower-case
 
-  # --- Subject ---
-  subject-empty:
-    - 2
-    - never
-  subject-full-stop:
-    - 2
-    - never
-    - "."
-
-  # --- Header ---
-  header-max-length:
-    - 2
-    - always
-    - 100
-
-  # --- Body ---
+  # Warn (not error) on long body lines; v20+ ignores lines containing URLs
   body-max-line-length:
     - 1
     - always
     - 100
-  body-leading-blank:
-    - 2
-    - always
-
-  # --- Footer ---
-  footer-leading-blank:
-    - 2
-    - always
 
 helpUrl: "https://www.conventionalcommits.org/"

--- a/.commitlintrc.yaml
+++ b/.commitlintrc.yaml
@@ -1,0 +1,71 @@
+# =============================================================================
+# Commitlint Configuration
+# =============================================================================
+# Enforces conventional commit message format.
+# Reference: https://commitlint.js.org/
+# =============================================================================
+
+extends:
+  - "@commitlint/config-conventional"
+
+rules:
+  # --- Type ---
+  type-enum:
+    - 2
+    - always
+    - - feat
+      - fix
+      - docs
+      - chore
+      - ci
+      - test
+      - refactor
+      - perf
+  type-case:
+    - 2
+    - always
+    - lower-case
+  type-empty:
+    - 2
+    - never
+
+  # --- Scope ---
+  scope-case:
+    - 2
+    - always
+    - lower-case
+
+  # --- Subject ---
+  subject-case:
+    - 2
+    - always
+    - lower-case
+  subject-empty:
+    - 2
+    - never
+  subject-full-stop:
+    - 2
+    - never
+    - "."
+
+  # --- Header ---
+  header-max-length:
+    - 2
+    - always
+    - 100
+
+  # --- Body ---
+  body-max-line-length:
+    - 1
+    - always
+    - 200
+  body-leading-blank:
+    - 2
+    - always
+
+  # --- Footer ---
+  footer-leading-blank:
+    - 2
+    - always
+
+helpUrl: "https://www.conventionalcommits.org/"

--- a/.cspell.json
+++ b/.cspell.json
@@ -26,15 +26,12 @@
     "rebase",
     "nix",
     "nixos",
-    "flake",
-    "endof"
+    "flake"
   ],
   "ignorePaths": [
     ".git",
     "node_modules",
     "*.json",
-    "*.yml",
-    "*.yaml",
     "*.toml",
     "LICENSE"
   ]

--- a/.cspell.json
+++ b/.cspell.json
@@ -26,13 +26,13 @@
     "rebase",
     "nix",
     "nixos",
-    "flake"
+    "flake",
+    "hotfix"
   ],
   "ignorePaths": [
     ".git",
     "node_modules",
     "*.json",
-    "*.toml",
     "LICENSE"
   ]
 }

--- a/.cspell.json
+++ b/.cspell.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://raw.githubusercontent.com/streetsidesoftware/cspell/main/cspell.schema.json",
+  "version": "0.2",
+  "language": "en",
+  "words": [
+    "commitlint",
+    "precommit",
+    "jacobpevans",
+    "markdownlint",
+    "cspell",
+    "semver",
+    "automerge",
+    "conventionalcommits",
+    "autoupdate",
+    "cchk",
+    "renovatebot",
+    "codecov",
+    "codeql",
+    "templated",
+    "triage",
+    "triaged",
+    "wontfix",
+    "kebab",
+    "signingkey",
+    "gpgsign",
+    "rebase",
+    "nix",
+    "nixos",
+    "flake",
+    "endof"
+  ],
+  "ignorePaths": [
+    ".git",
+    "node_modules",
+    "*.json",
+    "*.yml",
+    "*.yaml",
+    "*.toml",
+    "LICENSE"
+  ]
+}

--- a/.cspell.json
+++ b/.cspell.json
@@ -27,7 +27,10 @@
     "nix",
     "nixos",
     "flake",
-    "hotfix"
+    "hotfix",
+    "commitlintrc",
+    "agentsmd",
+    "frontmatter"
   ],
   "ignorePaths": [
     ".git",

--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -2,6 +2,9 @@
   "ignorePatterns": [
     {
       "pattern": "^#"
+    },
+    {
+      "pattern": "^\\.\\./docs/"
     }
   ],
   "timeout": "10s",

--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -7,5 +7,5 @@
   "timeout": "10s",
   "retryOn429": true,
   "retryCount": 3,
-  "aliveStatusCodes": [200, 206, 301, 302]
+  "aliveStatusCodes": [200, 206, 301, 302, 307, 308]
 }

--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -1,0 +1,11 @@
+{
+  "ignorePatterns": [
+    {
+      "pattern": "^#"
+    }
+  ],
+  "timeout": "10s",
+  "retryOn429": true,
+  "retryCount": 3,
+  "aliveStatusCodes": [200, 206, 301, 302]
+}

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,5 +1,17 @@
 {
   "MD013": {
-    "line_length": 160
+    "line_length": 160,
+    "heading_line_length": 120,
+    "code_block_line_length": 200
+  },
+  "MD024": {
+    "siblings_only": true
+  },
+  "MD033": {
+    "allowed_elements": ["br", "details", "summary", "blockquote", "sup"]
+  },
+  "MD041": true,
+  "MD046": {
+    "style": "fenced"
   }
 }

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -7,6 +7,7 @@
   "MD024": {
     "siblings_only": true
   },
+  "MD025": true,
   "MD033": {
     "allowed_elements": ["br", "details", "summary", "blockquote", "sup"]
   },

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # Pre-commit Configuration
 # =============================================================================
 # Foundation hooks for local development. Install with:
-#   pip install pre-commit && pre-commit install
+#   pip install pre-commit && pre-commit install --hook-type commit-msg --hook-type pre-push
 #
 # Run manually: pre-commit run --all-files
 # Update hooks: pre-commit autoupdate
@@ -74,4 +74,3 @@ repos:
       - id: check-branch
         name: Check branch naming conventions
         stages: [pre-push]
-        args: [--config, cchk.toml]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # Pre-commit Configuration
 # =============================================================================
 # Foundation hooks for local development. Install with:
-#   pip install pre-commit && pre-commit install --hook-type pre-commit --hook-type commit-msg
+#   pip install pre-commit && pre-commit install
 #
 # Run manually: pre-commit run --all-files
 # Update hooks: pre-commit autoupdate
@@ -13,7 +13,7 @@ repos:
   # Base hooks - standard file hygiene
   # ---------------------------------------------------------------------------
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-yaml
         name: Validate YAML syntax
@@ -33,7 +33,7 @@ repos:
   # Markdown linting
   # ---------------------------------------------------------------------------
   - repo: https://github.com/DavidAnson/markdownlint-cli2
-    rev: v0.17.2
+    rev: v0.20.0
     hooks:
       - id: markdownlint-cli2
         name: Lint markdown files
@@ -42,7 +42,7 @@ repos:
   # Spell checking
   # ---------------------------------------------------------------------------
   - repo: https://github.com/streetsidesoftware/cspell-cli
-    rev: v8.17.3
+    rev: v9.6.0
     hooks:
       - id: cspell
         name: Check spelling
@@ -51,7 +51,7 @@ repos:
   # Link checking
   # ---------------------------------------------------------------------------
   - repo: https://github.com/tcort/markdown-link-check
-    rev: v3.13.6
+    rev: v3.14.2
     hooks:
       - id: markdown-link-check
         name: Check markdown links
@@ -61,16 +61,16 @@ repos:
   # Commit message validation (commit-msg stage)
   # ---------------------------------------------------------------------------
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
-    rev: v9.21.0
+    rev: v9.24.0
     hooks:
       - id: commitlint
         name: Validate commit message format
         stages: [commit-msg]
-        additional_dependencies: ["@commitlint/config-conventional"]
+        additional_dependencies: ["@commitlint/config-conventional@19.8.0"]
 
   - repo: https://github.com/commit-check/commit-check
-    rev: v0.9.3
+    rev: v2.4.1
     hooks:
-      - id: check-message
-        name: Check commit message conventions
-        stages: [commit-msg]
+      - id: check-branch
+        name: Check branch naming conventions
+        stages: [push]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,7 +66,7 @@ repos:
       - id: commitlint
         name: Validate commit message format
         stages: [commit-msg]
-        additional_dependencies: ["@commitlint/config-conventional@19.8.0"]
+        additional_dependencies: ["@commitlint/config-conventional@20.4.1"]
 
   - repo: https://github.com/commit-check/commit-check
     rev: v2.4.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,4 +73,5 @@ repos:
     hooks:
       - id: check-branch
         name: Check branch naming conventions
-        stages: [push]
+        stages: [pre-push]
+        args: [--config, cchk.toml]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,76 @@
+# =============================================================================
+# Pre-commit Configuration
+# =============================================================================
+# Foundation hooks for local development. Install with:
+#   pip install pre-commit && pre-commit install --hook-type pre-commit --hook-type commit-msg
+#
+# Run manually: pre-commit run --all-files
+# Update hooks: pre-commit autoupdate
+# =============================================================================
+
+repos:
+  # ---------------------------------------------------------------------------
+  # Base hooks - standard file hygiene
+  # ---------------------------------------------------------------------------
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-yaml
+        name: Validate YAML syntax
+      - id: end-of-file-fixer
+        name: Fix end-of-file newlines
+      - id: trailing-whitespace
+        name: Trim trailing whitespace
+      - id: check-case-conflict
+        name: Check for case conflicts
+      - id: check-merge-conflict
+        name: Check for merge conflict markers
+      - id: mixed-line-ending
+        name: Normalize line endings
+        args: [--fix=lf]
+
+  # ---------------------------------------------------------------------------
+  # Markdown linting
+  # ---------------------------------------------------------------------------
+  - repo: https://github.com/DavidAnson/markdownlint-cli2
+    rev: v0.17.2
+    hooks:
+      - id: markdownlint-cli2
+        name: Lint markdown files
+
+  # ---------------------------------------------------------------------------
+  # Spell checking
+  # ---------------------------------------------------------------------------
+  - repo: https://github.com/streetsidesoftware/cspell-cli
+    rev: v8.17.3
+    hooks:
+      - id: cspell
+        name: Check spelling
+
+  # ---------------------------------------------------------------------------
+  # Link checking
+  # ---------------------------------------------------------------------------
+  - repo: https://github.com/tcort/markdown-link-check
+    rev: v3.13.6
+    hooks:
+      - id: markdown-link-check
+        name: Check markdown links
+        args: [--config, .markdown-link-check.json]
+
+  # ---------------------------------------------------------------------------
+  # Commit message validation (commit-msg stage)
+  # ---------------------------------------------------------------------------
+  - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
+    rev: v9.21.0
+    hooks:
+      - id: commitlint
+        name: Validate commit message format
+        stages: [commit-msg]
+        additional_dependencies: ["@commitlint/config-conventional"]
+
+  - repo: https://github.com/commit-check/commit-check
+    rev: v0.9.3
+    hooks:
+      - id: check-message
+        name: Check commit message conventions
+        stages: [commit-msg]

--- a/cchk.toml
+++ b/cchk.toml
@@ -1,0 +1,33 @@
+# =============================================================================
+# commit-check Configuration
+# =============================================================================
+# Validates commit messages and branch names against conventional standards.
+# Reference: https://github.com/commit-check/commit-check
+# =============================================================================
+
+[commit.message]
+regex = "^(feat|fix|docs|chore|ci|test|refactor|perf)(\\(.+\\))?!?: .{1,100}"
+error = """Bad commit message format. Required: type(scope): description
+
+Allowed types: feat, fix, docs, chore, ci, test, refactor, perf
+Examples:
+  feat(api): add user authentication
+  fix(ui): resolve button alignment
+  docs(readme): update installation instructions
+  chore(deps): update dependencies
+  feat!: remove deprecated v1 API (breaking change)
+
+Reference: https://www.conventionalcommits.org/"""
+
+[commit.branch]
+regex = "^(main|develop|feat/|fix/|docs/|chore/|ci/|test/|refactor/|perf/|release/|hotfix/|claude/).+"
+error = """Bad branch name. Required format: type/description
+
+Allowed prefixes: feat/, fix/, docs/, chore/, ci/, test/, refactor/, perf/, release/, hotfix/, claude/
+Protected branches: main, develop
+
+Examples:
+  feat/add-user-auth
+  fix/button-alignment
+  docs/update-readme
+  chore/update-deps"""

--- a/cchk.toml
+++ b/cchk.toml
@@ -1,26 +1,13 @@
 # =============================================================================
 # commit-check Configuration
 # =============================================================================
-# Validates commit messages and branch names against conventional standards.
+# Validates branch names against conventional standards.
+# Commit message validation is handled by commitlint (.commitlintrc.yaml).
 # Reference: https://github.com/commit-check/commit-check
 # =============================================================================
 
-[commit.message]
-regex = "^(feat|fix|docs|chore|ci|test|refactor|perf)(\\(.+\\))?!?: .{1,100}"
-error = """Bad commit message format. Required: type(scope): description
-
-Allowed types: feat, fix, docs, chore, ci, test, refactor, perf
-Examples:
-  feat(api): add user authentication
-  fix(ui): resolve button alignment
-  docs(readme): update installation instructions
-  chore(deps): update dependencies
-  feat!: remove deprecated v1 API (breaking change)
-
-Reference: https://www.conventionalcommits.org/"""
-
 [commit.branch]
-regex = "^(main|develop|feat/|fix/|docs/|chore/|ci/|test/|refactor/|perf/|release/|hotfix/|claude/).+"
+regex = "^(main|develop|(?:feat|fix|docs|chore|ci|test|refactor|perf|release|hotfix|claude)/.+)$"
 error = """Bad branch name. Required format: type/description
 
 Allowed prefixes: feat/, fix/, docs/, chore/, ci/, test/, refactor/, perf/, release/, hotfix/, claude/

--- a/cchk.toml
+++ b/cchk.toml
@@ -6,15 +6,19 @@
 # Reference: https://github.com/commit-check/commit-check
 # =============================================================================
 
-[commit.branch]
-regex = "^(main|develop|(?:feat|fix|docs|chore|ci|test|refactor|perf|release|hotfix|claude)/.+)$"
-error = """Bad branch name. Required format: type/description
-
-Allowed prefixes: feat/, fix/, docs/, chore/, ci/, test/, refactor/, perf/, release/, hotfix/, claude/
-Protected branches: main, develop
-
-Examples:
-  feat/add-user-auth
-  fix/button-alignment
-  docs/update-readme
-  chore/update-deps"""
+[branch]
+conventional_branch = true
+allow_branch_types = [
+  "feat",
+  "fix",
+  "docs",
+  "chore",
+  "ci",
+  "test",
+  "refactor",
+  "perf",
+  "release",
+  "hotfix",
+  "claude",
+]
+allow_branch_names = ["main", "develop"]

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -166,7 +166,7 @@ I'll probably accept most reasonable PRs. This is a documentation repo, not a nu
 ## Development Setup
 
 1. Clone the repo
-2. Install pre-commit: `pip install pre-commit && pre-commit install`
+2. Install pre-commit: `pip install pre-commit && pre-commit install --hook-type commit-msg --hook-type pre-push`
 3. Make changes
 4. Commit and push
 


### PR DESCRIPTION
## Summary

Adds pre-commit hooks and supporting configuration to enforce code quality standards, conventional commit messages, and branch naming conventions.

## Changes

### Pre-commit Hooks (`.pre-commit-config.yaml`)
- **File hygiene**: YAML validation, trailing whitespace, line endings, merge conflicts, case conflicts
- **Markdown linting**: markdownlint-cli2
- **Spell checking**: cspell with project-specific allowlist
- **Link validation**: markdown-link-check with retry and redirect handling
- **Commit messages**: commitlint at commit-msg stage
- **Branch naming**: commit-check at pre-push stage

### Tool Configuration
| File | Purpose |
|------|---------|
| `.commitlintrc.yaml` | Conventional commit format — custom type list (adds `breaking`, removes `build`/`revert`/`style`), body-leading-blank and footer-leading-blank promoted to error |
| `cchk.toml` | Branch naming — allows `feat/`, `fix/`, `docs/`, `chore/`, `ci/`, `test/`, `refactor/`, `perf/`, `release/`, `hotfix/`, `claude/` prefixes plus `main`/`develop` |
| `.cspell.json` | Spell checker — project word allowlist, ignores `.git`, `node_modules`, `*.json`, `LICENSE` |
| `.markdown-link-check.json` | Link checker — retry on 429, accepts 2xx/3xx status codes, ignores `#` anchors and `../docs/` relative paths |
| `.markdownlint.json` | Markdown rules — 160-char line length, 120 for headings, 200 for code blocks, siblings-only duplicate headings, allowed HTML elements |

### Other
- Updated `docs/CONTRIBUTING.md` install instructions to include `--hook-type commit-msg --hook-type pre-push`
- All hook versions pinned to latest: pre-commit-hooks v6.0.0, markdownlint-cli2 v0.20.0, cspell-cli v9.6.0, markdown-link-check v3.14.2, commitlint-pre-commit-hook v9.24.0, commit-check v2.4.1, @commitlint/config-conventional@20.4.1

## Design Decisions
- **commitlint handles commit messages, commit-check handles branch names** — no overlap
- **commitlint config only overrides 4 rules** that differ from `@commitlint/config-conventional` defaults
- **body-max-line-length is a warning** (not error) — v20+ ignores URL-containing lines
- **`cchk.toml` is auto-discovered** by commit-check (default search path), no `--config` arg needed

## Test Plan
- [x] All pre-commit hooks pass on commit
- [x] All pre-push hooks pass (including branch validation with correct config format)
- [x] cspell catches misspellings in TOML and YAML files
- [x] markdown-link-check ignores PR template relative paths

Closes #25, Closes #26, Closes #29, Closes #31, Closes #40, Closes #41, Closes #42