### PR TITLE
feat: add AI assistant configuration templates

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -30,7 +30,10 @@
     "hotfix",
     "commitlintrc",
     "agentsmd",
-    "frontmatter"
+    "frontmatter",
+    "styleguide",
+    "venv",
+    "pycache"
   ],
   "ignorePaths": [
     ".git",

--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,11 @@
+code_review:
+  comment_severity_threshold: MEDIUM
+  pull_request_opened:
+    summary: true
+    code_review: true
+
+ignore_patterns:
+  - "node_modules/**"
+  - ".git/**"
+  - "*.log"
+  - ".tmp/**"

--- a/README.md
+++ b/README.md
@@ -61,10 +61,11 @@ According to [GitHub's documentation][supported-files], the following files can 
 
 Documentation files (inheritable by other repositories):
 
-| File                   | Purpose                     | Inherited? | Documentation                      |
-| ---------------------- | --------------------------- | ---------- | ---------------------------------- |
-| `docs/CONTRIBUTING.md` | Contribution guidelines     | Yes        | [About CONTRIBUTING][contrib-docs] |
-| `docs/LABELS.md`       | Label system documentation  | No         | -                                  |
+| File                          | Purpose                        | Inherited? | Documentation                      |
+| ----------------------------- | ------------------------------ | ---------- | ---------------------------------- |
+| `docs/CONTRIBUTING.md`        | Contribution guidelines        | Yes        | [About CONTRIBUTING][contrib-docs] |
+| `docs/LABELS.md`              | Label system documentation     | No         | -                                  |
+| `docs/AI_ASSISTANT_CONFIG.md` | AI review tool setup templates | No         | -                                  |
 
 [contrib-docs]: https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/setting-guidelines-for-repository-contributors
 

--- a/docs/AI_ASSISTANT_CONFIG.md
+++ b/docs/AI_ASSISTANT_CONFIG.md
@@ -1,0 +1,48 @@
+# AI Assistant Configuration Templates
+
+Reusable templates for GitHub Copilot and Gemini Code Assist.
+
+## Quick Start
+
+**For any repo**: Copy these files and customize for your project:
+
+1. **`.github/copilot-instructions.md`** - Code review standards (inline, ~200 lines)
+2. **`.gemini/config.yaml`** - Gemini configuration (minimal, ~15 lines)
+3. **`.gemini/styleguide.md`** - Coding style guide (inline, ~200 lines)
+
+**For repos with agentsmd/ structure** (like ai-assistant-instructions):
+
+See ai-assistant-instructions repo for symlink patterns. Symlink to agentsmd/ files instead of copying inline content.
+
+## Template Files
+
+Copy from ai-assistant-instructions repo:
+
+- `agentsmd/docs/code_review_instructions.md` → Your `.github/copilot-instructions.md`
+- `agentsmd/rules/styleguide.md` → Your `.gemini/styleguide.md`
+- `agentsmd/rules/code-standards.md` → Reference for logging format and security patterns
+
+Customize for your project's language and conventions.
+
+## Minimal Template: .gemini/config.yaml
+
+```yaml
+code_review:
+  comment_severity_threshold: MEDIUM
+  pull_request_opened:
+    summary: true
+    code_review: true
+
+ignore_patterns:
+  - "node_modules/**"
+  - ".git/**"
+  - "*.log"
+  - ".tmp/**"
+```
+
+Add project-specific ignore patterns (terraform, venv, `__pycache__`, etc.) as needed.
+
+## Official Documentation
+
+- [GitHub Copilot Instructions](https://docs.github.com/en/copilot/how-tos/configure-custom-instructions/add-repository-instructions)
+- [Gemini Code Assist](https://developers.google.com/gemini-code-assist/docs/customize-gemini-behavior-github)

--- a/docs/AI_ASSISTANT_CONFIG.md
+++ b/docs/AI_ASSISTANT_CONFIG.md
@@ -4,25 +4,25 @@ Reusable templates for GitHub Copilot and Gemini Code Assist.
 
 ## Quick Start
 
-**For any repo**: Copy these files and customize for your project:
+**For any repo**: Create these files and customize for your project:
 
-1. **`.github/copilot-instructions.md`** - Code review standards (inline, ~200 lines)
-2. **`.gemini/config.yaml`** - Gemini configuration (minimal, ~15 lines)
-3. **`.gemini/styleguide.md`** - Coding style guide (inline, ~200 lines)
+1. **`.github/copilot-instructions.md`** - Code review standards (~200 lines, sourced from ai-assistant-instructions repo)
+2. **`.gemini/config.yaml`** - Gemini configuration (~15 lines, minimal template below)
+3. **`.gemini/styleguide.md`** - Coding style guide (~200 lines, sourced from ai-assistant-instructions repo)
 
 **For repos with agentsmd/ structure** (like ai-assistant-instructions):
 
-See ai-assistant-instructions repo for symlink patterns. Symlink to agentsmd/ files instead of copying inline content.
+Symlink to agentsmd/ files instead of copying. See ai-assistant-instructions repo for symlink patterns.
 
-## Template Files
+## Template Sources
 
-Copy from ai-assistant-instructions repo:
+Copy from the `ai-assistant-instructions` repo and customize for your project:
 
 - `agentsmd/docs/code_review_instructions.md` → Your `.github/copilot-instructions.md`
 - `agentsmd/rules/styleguide.md` → Your `.gemini/styleguide.md`
 - `agentsmd/rules/code-standards.md` → Reference for logging format and security patterns
 
-Customize for your project's language and conventions.
+For `.gemini/config.yaml`, use the minimal template below (not sourced from ai-assistant-instructions).
 
 ## Minimal Template: .gemini/config.yaml
 


### PR DESCRIPTION
## Summary

- Add `docs/AI_ASSISTANT_CONFIG.md` with setup guidance for GitHub Copilot and Gemini Code Assist
- Add minimal `.gemini/config.yaml` template with only non-default settings
- Update README.md docs table to reference new AI assistant config documentation
- Add spelling exceptions (styleguide, venv, pycache) to `.cspell.json`

Provides copy-paste templates for configuring AI code review tools across all JacobPEvans repositories. For repos with agentsmd/ structure (like ai-assistant-instructions), guidance points to symlinking instead of inline copying.

## Test plan

- [ ] Verify template files exist: `ls -la .gemini/config.yaml docs/AI_ASSISTANT_CONFIG.md`
- [ ] Confirm README table renders correctly on GitHub
- [ ] Test copying template config to another repo
- [ ] Verify all pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add AI assistant configuration templates and update documentation for GitHub Copilot and Gemini Code Assist.
> 
>   - **AI Assistant Configuration**:
>     - Add `docs/AI_ASSISTANT_CONFIG.md` with setup guidance for GitHub Copilot and Gemini Code Assist.
>     - Add minimal `.gemini/config.yaml` template with non-default settings.
>   - **Documentation**:
>     - Update `README.md` to include reference to new AI assistant config documentation.
>   - **Misc**:
>     - Add spelling exceptions (styleguide, venv, pycache) to `.cspell.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2F.github&utm_source=github&utm_medium=referral)<sup> for 9f2d30924735f6be70f7cd200b5efe73c142bbe2. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->