### PR TITLE
docs: add label-sync workflow and update sync documentation

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -2,7 +2,7 @@
 # JacobPEvans Standard Labels
 # =============================================================================
 # Canonical label set for all repositories.
-# Synced via EndBug/label-sync GitHub Action.
+# Synced to all repos via .github/workflows/label-sync.yml on push to main.
 #
 # Categories:
 #   type:*     - What kind of change (aligns with semantic versioning)

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -1,0 +1,36 @@
+name: Sync labels from labels.yml
+
+on:
+  push:
+    branches: [main]
+    paths: [.github/labels.yml]
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Sync labels to this repo
+        uses: EndBug/label-sync@v2
+        with:
+          config-file: .github/labels.yml
+          delete-other-labels: true
+
+      - name: Sync labels to all other repos
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT_WORKFLOW_DISPATCH }}
+        run: |
+          # Get all public repos except .github (already synced above)
+          repos=$(gh repo list JacobPEvans --public --json name --limit 100 \
+            | jq -r '.[].name | select(. != ".github")')
+
+          for repo in $repos; do
+            echo "Syncing labels to $repo..."
+            gh label clone JacobPEvans/.github -R "JacobPEvans/$repo" --force || \
+              echo "  Warning: failed to sync $repo"
+          done

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -9,25 +9,38 @@ on:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    # permissions for GITHUB_TOKEN (used by EndBug/label-sync on this repo only).
+    # Cross-repo operations use GH_PAT_WORKFLOW_DISPATCH PAT instead.
     permissions:
       contents: read
       issues: write
     steps:
       - uses: actions/checkout@v4
 
-      - name: Sync labels to this repo
+      # Step 1: Sync labels.yml -> this repo's GitHub labels via EndBug/label-sync.
+      # This ensures .github repo matches the file before step 2 clones from it.
+      - name: Sync labels to this repo from labels.yml
         uses: EndBug/label-sync@v2
         with:
           config-file: .github/labels.yml
           delete-other-labels: true
 
-      - name: Sync labels to all other repos
+      # Step 2: Clone from .github (now guaranteed in sync with labels.yml) to
+      # all other public repos. Private repos are intentionally excluded.
+      - name: Sync labels to all other public repos
         env:
           GH_TOKEN: ${{ secrets.GH_PAT_WORKFLOW_DISPATCH }}
         run: |
-          # Get all public repos except .github (already synced above)
           repos=$(gh repo list JacobPEvans --public --json name --limit 100 \
-            | jq -r '.[].name | select(. != ".github")')
+            | jq -r '.[].name | select(. != ".github")') || {
+            echo "Error: Failed to fetch repository list"
+            exit 1
+          }
+
+          if [ -z "$repos" ]; then
+            echo "Warning: No repositories found to sync"
+            exit 0
+          fi
 
           for repo in $repos; do
             echo "Syncing labels to $repo..."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ Must follow [Conventional Commits](https://www.conventionalcommits.org/):
 
 ## Labels (Required per issue and PR)
 
-- `type:*` - One+ required: bug|feature|breaking|docs|chore|ci|test|refactor|perf
+- `type:*` - One+ required: bug|feature|breaking|docs|chore|ci|test|refactor|perf|security
 - `priority:*` - Exactly one: critical|high|medium|low
 - `size:*` - Exactly one: xs|s|m|l|xl
 
@@ -46,8 +46,10 @@ Must follow [Conventional Commits](https://www.conventionalcommits.org/):
 - `ready-for-dev` → Requirements clarified, ready to implement
 - `good-first-issue` → Good for newcomers
 
-## Sync Labels to Repo
+## Sync Labels to Repos
 
-```bash
-gh label clone JacobPEvans/.github -R JacobPEvans/TARGET --force
-```
+Labels deploy automatically from `labels.yml` via the `label-sync` workflow on push to main.
+
+Manual trigger: `gh workflow run label-sync.yml -R JacobPEvans/.github`
+
+> Avoid `gh label clone` — it copies repo state, not `labels.yml`.

--- a/README.md
+++ b/README.md
@@ -141,12 +141,17 @@ Standardized [pull request templates][pr-templates-docs] that enforce convention
 
 [GitHub Actions workflows][workflows-docs] that automate label management:
 
-| Workflow                | Purpose                                                                  | Trigger        | Documentation                     |
-| ----------------------- | ------------------------------------------------------------------------ | -------------- | --------------------------------- |
-| `auto-label-issues.yml` | Automatically applies priority and size labels from issue form dropdowns | Issue creation | [Using workflows][workflows-docs] |
+| Workflow                 | Purpose                              | Trigger                   |
+| ------------------------ | ------------------------------------ | ------------------------- |
+| `auto-label-issues.yml`  | Apply priority/size from issue forms | Issue creation            |
+| `label-sync.yml`         | Deploy `labels.yml` to all repos     | Push to main, manual      |
 
-**How it works**: When an issue is created from a template, the workflow extracts the user's dropdown selections (priority and size).
-It then applies the corresponding labels automatically.
+**Auto-label**: When an issue is created from a template, the workflow extracts
+the user's dropdown selections (priority and size) and applies labels.
+
+**Label sync**: When `labels.yml` is updated and pushed to main, deploys the
+canonical labels to all repositories.
+Can also be triggered manually via `workflow_dispatch`.
 
 [workflows-docs]: https://docs.github.com/en/actions/using-workflows/about-workflows
 
@@ -158,10 +163,11 @@ All repositories use a consistent labeling taxonomy for issue classification and
 
 ### Quick Reference
 
-- **Type labels** (`type:*`): bug, feature, breaking, docs, chore, ci, test, refactor, perf
+- **Type labels** (`type:*`): bug, feature, breaking, docs, chore, ci, test, refactor, perf, security
 - **Priority labels** (`priority:*`): critical, high, medium, low
 - **Size labels** (`size:*`): xs, s, m, l, xl
-- **AI workflow labels** (`ai:*`): created, ready
+- **AI workflow labels** (`ai:*`): created, ready, reviewed, skip-review
+- **Workflow labels**: ready-for-dev, good-first-issue
 - **Triage labels**: duplicate, invalid, wontfix, question
 
 **Learn More**: [Managing labels - GitHub Docs](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels)
@@ -193,14 +199,20 @@ Create your own version of a file in your repository to override the default.
 
 ### Option 3: Sync Labels
 
-Labels are **not inherited** automatically. Use the [GitHub CLI](https://cli.github.com/) to sync them from `.github/labels.yml`:
+Labels are **not inherited** automatically.
+The [label-sync workflow](.github/workflows/label-sync.yml) deploys labels
+from [`.github/labels.yml`](.github/labels.yml) to all repositories
+whenever the file is updated on `main`.
+
+To trigger a manual sync:
 
 ```bash
-# One-time sync from this repo to another
-gh label clone JacobPEvans/.github -R JacobPEvans/YOUR_REPO --force
+gh workflow run label-sync.yml -R JacobPEvans/.github
 ```
 
-**Why `--force`?** Updates existing labels and creates new ones. Without it, the command fails if labels already exist.
+> **Note**: Avoid using `gh label clone` for cross-repo syncing.
+> It copies from a repo's current GitHub label state, not from
+> `labels.yml`, which can propagate drift.
 
 **Learn More**: [GitHub CLI manual](https://cli.github.com/manual/)
 

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ All repositories use a consistent labeling taxonomy for issue classification and
 - **Priority labels** (`priority:*`): critical, high, medium, low
 - **Size labels** (`size:*`): xs, s, m, l, xl
 - **AI workflow labels** (`ai:*`): created, ready, reviewed, skip-review
-- **Workflow labels**: ready-for-dev, good-first-issue
+- **Development readiness labels**: ready-for-dev, good-first-issue
 - **Triage labels**: duplicate, invalid, wontfix, question
 
 **Learn More**: [Managing labels - GitHub Docs](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels)

--- a/docs/LABELS.md
+++ b/docs/LABELS.md
@@ -165,20 +165,6 @@ To trigger a manual sync:
 gh workflow run label-sync.yml -R JacobPEvans/.github
 ```
 
-### Manual Sync
-
-If you need to sync labels manually, use `gh label clone` to copy from a repo that is already in sync with `labels.yml`:
-
-```bash
-gh label clone JacobPEvans/.github -R JacobPEvans/TARGET_REPO --force
-```
-
-**About the `--force` flag**: Updates existing labels with new colors and descriptions, and creates labels that don't exist.
-
-> **Warning**: `gh label clone` copies from a repo's **current GitHub labels**, not from `labels.yml`.
-> If the source repo's labels have drifted from `labels.yml`, the clone will propagate stale data.
-> Always verify the source repo matches `labels.yml` before cloning, or use the automated workflow instead.
-
 ### Post-Sync Cleanup
 
 After syncing, check for legacy GitHub default labels that conflict with the canonical set.


### PR DESCRIPTION
## Summary

- Add `label-sync.yml` workflow that deploys from `labels.yml` to all repos on push to main or manual trigger
- Replace `gh label clone` instructions with automated workflow references across README, LABELS.md, and AGENTS.md
- Add missing labels (`type:security`, `ai:reviewed`, `ai:skip-review`, `ready-for-dev`, `good-first-issue`) to quick reference sections
- Warn against repo-to-repo cloning which copies current label state rather than the canonical `labels.yml`

## Context

During a cross-repo label sync, `gh label clone JacobPEvans/.github` propagated stale labels because
the `.github` repo's actual GitHub labels had drifted from `labels.yml`. This PR ensures the file is
always the source of truth by automating deployment from it.

## Test plan

- [ ] Verify `label-sync.yml` workflow syntax is valid
- [ ] Confirm `GH_PAT_WORKFLOW_DISPATCH` secret has `public_repo` scope for cross-repo label operations
- [ ] Trigger manual workflow run: `gh workflow run label-sync.yml -R JacobPEvans/.github`
- [ ] Verify labels deploy correctly to at least one target repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `label-sync.yml` workflow for automated label synchronization and update documentation to reflect new process.
> 
>   - **Workflows**:
>     - Add `label-sync.yml` workflow to sync labels from `labels.yml` to all repos on push to main or manual trigger.
>   - **Documentation**:
>     - Replace `gh label clone` instructions with `label-sync` workflow references in `README.md`, `LABELS.md`, and `AGENTS.md`.
>     - Add missing labels (`type:security`, `ai:reviewed`, `ai:skip-review`, `ready-for-dev`, `good-first-issue`) to quick reference sections.
>     - Warn against repo-to-repo cloning which copies current label state rather than `labels.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2F.github&utm_source=github&utm_medium=referral)<sup> for 3a162aaab66a3a8906c2615f62e190fee276e19a. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->