### PR TITLE
feat(renovate): add shared preset with org-wide auto-merge rules

### DIFF
--- a/renovate-presets.json
+++ b/renovate-presets.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "JacobPEvans org-wide Renovate preset",
+  "platformAutomerge": true,
+  "packageRules": [
+    {
+      "description": "Auto-merge JacobPEvans-owned GitHub Actions (all update types, immediate)",
+      "matchDatasources": ["github-actions"],
+      "matchPackagePrefixes": ["JacobPEvans/"],
+      "automerge": true,
+      "automergeType": "squash",
+      "minimumReleaseAge": "0 days"
+    },
+    {
+      "description": "Auto-merge official GitHub Actions (all update types)",
+      "matchDatasources": ["github-actions"],
+      "matchPackagePrefixes": ["actions/"],
+      "automerge": true,
+      "automergeType": "squash",
+      "minimumReleaseAge": "3 days"
+    },
+    {
+      "description": "Auto-merge release-please (all update types)",
+      "matchDatasources": ["github-actions"],
+      "matchPackagePrefixes": ["googleapis/"],
+      "automerge": true,
+      "automergeType": "squash",
+      "minimumReleaseAge": "3 days"
+    },
+    {
+      "description": "Auto-merge Anthropic GitHub Actions (all update types)",
+      "matchDatasources": ["github-actions"],
+      "matchPackagePrefixes": ["anthropics/"],
+      "automerge": true,
+      "automergeType": "squash",
+      "minimumReleaseAge": "3 days"
+    },
+    {
+      "description": "Auto-merge pre-commit hooks (minor and patch)",
+      "matchManagers": ["pre-commit"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true,
+      "automergeType": "squash"
+    }
+  ]
+}

--- a/renovate-presets.json
+++ b/renovate-presets.json
@@ -8,31 +8,19 @@
       "matchDatasources": ["github-actions"],
       "matchPackagePrefixes": ["JacobPEvans/"],
       "automerge": true,
-      "automergeType": "squash",
+      "automergeType": "pr",
       "minimumReleaseAge": "0 days"
     },
     {
-      "description": "Auto-merge official GitHub Actions (all update types)",
+      "description": "Auto-merge trusted GitHub Actions (all update types)",
       "matchDatasources": ["github-actions"],
-      "matchPackagePrefixes": ["actions/"],
+      "matchPackagePrefixes": [
+        "actions/",
+        "googleapis/",
+        "anthropics/"
+      ],
       "automerge": true,
-      "automergeType": "squash",
-      "minimumReleaseAge": "3 days"
-    },
-    {
-      "description": "Auto-merge release-please (all update types)",
-      "matchDatasources": ["github-actions"],
-      "matchPackagePrefixes": ["googleapis/"],
-      "automerge": true,
-      "automergeType": "squash",
-      "minimumReleaseAge": "3 days"
-    },
-    {
-      "description": "Auto-merge Anthropic GitHub Actions (all update types)",
-      "matchDatasources": ["github-actions"],
-      "matchPackagePrefixes": ["anthropics/"],
-      "automerge": true,
-      "automergeType": "squash",
+      "automergeType": "pr",
       "minimumReleaseAge": "3 days"
     },
     {
@@ -40,7 +28,7 @@
       "matchManagers": ["pre-commit"],
       "matchUpdateTypes": ["minor", "patch"],
       "automerge": true,
-      "automergeType": "squash"
+      "automergeType": "pr"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "local>JacobPEvans/.github:renovate-presets"
   ]
 }


### PR DESCRIPTION
## Summary

- Creates `renovate-presets.json` — an org-wide shared preset with auto-merge rules for trusted publishers: `JacobPEvans/` (immediate), `actions/`, `googleapis/`, `anthropics/` (3-day minimum), and pre-commit minor/patch
- Updates `renovate.json` to extend the preset, covering the 6 repos with no local config
- Uses `platformAutomerge: true` so GitHub's native auto-merge is enabled at PR creation time

## Why

Renovate PRs from trusted first-party actions (e.g., `JacobPEvans/ai-workflows`) sit waiting for manual merge. This preset ensures they auto-merge immediately. Per-repo configs will be updated in follow-up PRs to extend this preset and remove duplicated rules.

## Test plan

- [ ] Verify Renovate can resolve the preset by checking Renovate logs after merge
- [ ] Confirm next Renovate PR in any repo gets GitHub auto-merge enabled at creation
- [ ] Merge this PR **before** the per-repo config PRs so the preset is resolvable

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds org-wide Renovate preset for auto-merging trusted updates and updates `renovate.json` to extend it.
> 
>   - **Behavior**:
>     - Adds `renovate-presets.json` with auto-merge rules for `JacobPEvans/` (immediate), `actions/`, `googleapis/`, `anthropics/` (3-day minimum), and pre-commit minor/patch.
>     - Updates `renovate.json` to extend the new preset, affecting 6 repos with no local config.
>     - Enables `platformAutomerge: true` for GitHub's native auto-merge at PR creation.
>   - **Purpose**:
>     - Automates merging of Renovate PRs from trusted sources to reduce manual intervention.
>     - Plans for future per-repo config updates to extend this preset and eliminate duplicate rules.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2F.github&utm_source=github&utm_medium=referral)<sup> for df1a495d8a201e0a7f5cfe6c0aff2972206be920. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->