### PR TITLE
feat: add reusable workflows, MIT license, and automation labels

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -33,7 +33,10 @@
     "frontmatter",
     "styleguide",
     "venv",
-    "pycache"
+    "pycache",
+    "narinfo",
+    "nixpkgs",
+    "Anson"
   ],
   "ignorePaths": [
     ".git",

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -157,3 +157,14 @@
 - name: "question"
   color: "E879F9"
   description: "Question - Further information is requested"
+
+# =============================================================================
+# AUTOMATION LABELS - Created by bots, preserved across label sync
+# =============================================================================
+- name: "dependencies"
+  color: "A5B4FC"
+  description: "Dependency updates - Automated by Renovate/Dependabot"
+
+- name: "renovate"
+  color: "A5B4FC"
+  description: "Renovate bot - Automated dependency management"

--- a/.github/workflows/_auto-merge.yml
+++ b/.github/workflows/_auto-merge.yml
@@ -1,0 +1,21 @@
+# Reusable: Auto Merge
+# Enables squash auto-merge on non-draft PRs.
+name: _auto-merge
+
+on:
+  workflow_call:
+
+jobs:
+  auto-merge:
+    name: Enable auto-merge
+    if: "!github.event.pull_request.draft"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Enable auto-merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.number }}
+        run: gh pr merge "$PR_NUMBER" --auto --squash --repo "$GITHUB_REPOSITORY"

--- a/.github/workflows/_file-size.yml
+++ b/.github/workflows/_file-size.yml
@@ -1,0 +1,68 @@
+# Reusable: File Size Check
+# Checks that no files exceed size limits. Uses repo's own config script if
+# available, otherwise falls back to inline defaults.
+name: _file-size
+
+on:
+  workflow_call:
+    inputs:
+      max-file-size-kb:
+        description: "Maximum file size in KB (default: 500)"
+        required: false
+        type: number
+        default: 500
+      max-line-count:
+        description: "Maximum line count per file (default: 1000)"
+        required: false
+        type: number
+        default: 1000
+
+concurrency:
+  group: file-size-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Check file sizes
+        env:
+          MAX_FILE_SIZE_KB: ${{ inputs.max-file-size-kb }}
+          MAX_LINE_COUNT: ${{ inputs.max-line-count }}
+        run: |
+          # Use repo's own script if available, otherwise inline check
+          if [ -x "./scripts/workflows/check-file-sizes.sh" ]; then
+            ./scripts/workflows/check-file-sizes.sh
+          else
+            EXIT_CODE=0
+
+            echo "=== File Size Check (max: ${MAX_FILE_SIZE_KB}KB) ==="
+            while IFS= read -r -d '' file; do
+              size_kb=$(( $(wc -c < "$file") / 1024 ))
+              if [ "$size_kb" -gt "$MAX_FILE_SIZE_KB" ]; then
+                echo "FAIL: $file (${size_kb}KB > ${MAX_FILE_SIZE_KB}KB)"
+                EXIT_CODE=1
+              fi
+            done < <(find . -type f -not -path './.git/*' -not -path './node_modules/*' -not -path './result*' -print0)
+
+            echo ""
+            echo "=== Line Count Check (max: ${MAX_LINE_COUNT} lines) ==="
+            while IFS= read -r -d '' file; do
+              if file "$file" | grep -q text; then
+                lines=$(wc -l < "$file")
+                if [ "$lines" -gt "$MAX_LINE_COUNT" ]; then
+                  echo "FAIL: $file (${lines} lines > ${MAX_LINE_COUNT})"
+                  EXIT_CODE=1
+                fi
+              fi
+            done < <(find . -type f -not -path './.git/*' -not -path './node_modules/*' -not -path './result*' -print0)
+
+            exit $EXIT_CODE
+          fi

--- a/.github/workflows/_markdown-lint.yml
+++ b/.github/workflows/_markdown-lint.yml
@@ -1,0 +1,28 @@
+# Reusable: Markdown Lint
+# Generic markdown linting — uses the calling repo's own markdownlint config.
+name: _markdown-lint
+
+on:
+  workflow_call:
+
+concurrency:
+  group: markdown-lint-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Run markdownlint
+        uses: DavidAnson/markdownlint-cli2-action@v22
+        with:
+          globs: |
+            **/*.md
+            !**/node_modules/**

--- a/.github/workflows/_nix-build.yml
+++ b/.github/workflows/_nix-build.yml
@@ -1,0 +1,69 @@
+# Reusable: Nix Build (macOS)
+# Builds a Nix flake on macOS with store caching.
+# Default build command targets home-manager; override for darwin-rebuild.
+name: _nix-build
+
+on:
+  workflow_call:
+    inputs:
+      build-command:
+        description: "Build command to run (default: home-manager build)"
+        required: false
+        type: string
+        default: "nix build .#homeConfigurations.$(whoami).activationPackage --print-build-logs"
+
+concurrency:
+  group: nix-build-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build
+    runs-on: macos-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Nix
+        uses: DeterminateSystems/determinate-nix-action@v3
+        with:
+          extra-conf: |
+            max-jobs = auto
+            cores = 0
+            http-connections = 50
+            connect-timeout = 5
+            stalled-download-timeout = 10
+            narinfo-cache-positive-ttl = 86400
+            fallback = true
+
+      - name: Restore Nix Store Cache
+        uses: actions/cache/restore@v5
+        id: nix-cache
+        with:
+          path: |
+            /nix/store
+            ~/.cache/nix
+          key: nix-macos-${{ runner.os }}-${{ hashFiles('flake.lock') }}
+          restore-keys: |
+            nix-macos-${{ runner.os }}-
+
+      - name: Build
+        run: ${{ inputs.build-command }}
+
+      - name: Garbage Collect Nix Store
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.nix-cache.outputs.cache-hit != 'true'
+        run: |
+          echo "Store size before GC: $(du -sh /nix/store | cut -f1)"
+          nix-collect-garbage --delete-older-than 1d
+          echo "Store size after GC: $(du -sh /nix/store | cut -f1)"
+
+      - name: Save Nix Store Cache
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.nix-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        with:
+          path: |
+            /nix/store
+            ~/.cache/nix
+          key: nix-macos-${{ runner.os }}-${{ hashFiles('flake.lock') }}

--- a/.github/workflows/_nix-validate.yml
+++ b/.github/workflows/_nix-validate.yml
@@ -1,0 +1,61 @@
+# Reusable: Nix Validate (Linux)
+# Runs nix flake check with CI-optimized Nix settings and store caching.
+name: _nix-validate
+
+on:
+  workflow_call:
+
+concurrency:
+  group: nix-validate-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Nix
+        uses: DeterminateSystems/determinate-nix-action@v3
+        with:
+          extra-conf: |
+            max-jobs = auto
+            cores = 0
+            http-connections = 50
+            connect-timeout = 5
+            stalled-download-timeout = 10
+            narinfo-cache-positive-ttl = 86400
+            fallback = true
+
+      - name: Restore Nix Store Cache
+        uses: actions/cache/restore@v5
+        id: nix-cache
+        with:
+          path: |
+            /nix/store
+            ~/.cache/nix
+          key: nix-linux-${{ runner.os }}-${{ hashFiles('flake.lock') }}
+          restore-keys: |
+            nix-linux-${{ runner.os }}-
+
+      - name: Lint flake.lock
+        uses: DeterminateSystems/flake-checker-action@main
+        with:
+          nixpkgs-keys: nixpkgs
+
+      - name: Check flake
+        run: nix flake check --print-build-logs
+
+      - name: Save Nix Store Cache
+        if: github.event_name == 'push' && steps.nix-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        with:
+          path: |
+            /nix/store
+            ~/.cache/nix
+          key: nix-linux-${{ runner.os }}-${{ hashFiles('flake.lock') }}

--- a/LICENSE
+++ b/LICENSE
@@ -1,201 +1,21 @@
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+MIT License
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+Copyright (c) 2025 Jacob P. Evans
 
-   1. Definitions.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ According to [GitHub's documentation][supported-files], the following files can 
 | File         | Purpose                                | Inherited? | Documentation |
 | ------------ | -------------------------------------- | ---------- | ------------- |
 | `README.md`  | This file                              | No         | -             |
-| `LICENSE`    | Apache License 2.0 for this repository | No         | -             |
+| `LICENSE`    | MIT License for this repository        | No         | -             |
 | `AGENTS.md`  | Quick reference for AI agents          | No         | -             |
 
 ### `docs/`
@@ -139,12 +139,20 @@ Standardized [pull request templates][pr-templates-docs] that enforce convention
 
 #### `.github/workflows/`
 
-[GitHub Actions workflows][workflows-docs] that automate label management:
+[GitHub Actions workflows][workflows-docs] for label management and reusable CI:
 
-| Workflow                 | Purpose                              | Trigger                   |
-| ------------------------ | ------------------------------------ | ------------------------- |
-| `auto-label-issues.yml`  | Apply priority/size from issue forms | Issue creation            |
-| `label-sync.yml`         | Deploy `labels.yml` to all repos     | Push to main, manual      |
+| Workflow                | Purpose                              | Trigger              |
+| ----------------------- | ------------------------------------ | -------------------- |
+| `auto-label-issues.yml` | Apply priority/size from issue forms | Issue creation       |
+| `label-sync.yml`        | Deploy `labels.yml` to all repos     | Push to main, manual |
+| `_auto-merge.yml`       | Reusable: squash auto-merge          | `workflow_call`      |
+| `_file-size.yml`        | Reusable: file size/line checks      | `workflow_call`      |
+| `_markdown-lint.yml`    | Reusable: markdownlint-cli2          | `workflow_call`      |
+| `_nix-build.yml`        | Reusable: Nix build (macOS)          | `workflow_call`      |
+| `_nix-validate.yml`     | Reusable: Nix flake check (Linux)    | `workflow_call`      |
+
+**Reusable workflows** (prefixed with `_`) are called by other repos via
+`uses: JacobPEvans/.github/.github/workflows/_name.yml@main`.
 
 **Auto-label**: When an issue is created from a template, the workflow extracts
 the user's dropdown selections (priority and size) and applies labels.
@@ -169,6 +177,7 @@ All repositories use a consistent labeling taxonomy for issue classification and
 - **AI workflow labels** (`ai:*`): created, ready, reviewed, skip-review
 - **Development readiness labels**: ready-for-dev, good-first-issue
 - **Triage labels**: duplicate, invalid, wontfix, question
+- **Automation labels**: dependencies, renovate
 
 **Learn More**: [Managing labels - GitHub Docs](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels)
 
@@ -218,7 +227,7 @@ gh workflow run label-sync.yml -R JacobPEvans/.github
 
 ## License
 
-All JacobPEvans repositories are licensed under the [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) unless otherwise noted.
+All JacobPEvans repositories are licensed under the [MIT License](https://opensource.org/licenses/MIT).
 Each repository contains its own `LICENSE` file as the authoritative license for that project,
 since GitHub does not support inheriting `LICENSE` files from a `.github` repository.
 


### PR DESCRIPTION
## Summary

- Replace Apache 2.0 with MIT license (year: 2025, Jacob P. Evans)
- Add reusable CI workflows: `_markdown-lint`, `_nix-validate`, `_nix-build`, `_file-size`, `_auto-merge`
- Add `dependencies` and `renovate` automation labels to `labels.yml`
- Update README to document new reusable workflows and license change

## Context

Part of the nix trio release polish. These reusable workflows will be called by nix-darwin, nix-ai, and nix-home repos to reduce workflow duplication.

## Test plan

- [ ] Label sync propagates new labels to all repos
- [ ] Reusable workflows are callable from other repos (verified after merge)
- [ ] README renders correctly with updated tables

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds reusable workflows, updates to MIT license, and new automation labels for improved CI and documentation.
> 
>   - **License**:
>     - Replaces Apache 2.0 with MIT license in `LICENSE` and updates `README.md` to reflect this change.
>   - **Workflows**:
>     - Adds reusable workflows `_auto-merge.yml`, `_file-size.yml`, `_markdown-lint.yml`, `_nix-build.yml`, and `_nix-validate.yml` for CI tasks.
>     - Workflows are designed to be called by other repositories via `workflow_call`.
>   - **Labels**:
>     - Adds `dependencies` and `renovate` automation labels to `labels.yml`.
>   - **Documentation**:
>     - Updates `README.md` to document new workflows and license change.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2F.github&utm_source=github&utm_medium=referral)<sup> for 6d518ac9306d406e9a61f12839b8f8288a63afe2. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->