### PR TITLE
ci: add reusable release-please workflow

### DIFF
--- a/.github/workflows/_release-please.yml
+++ b/.github/workflows/_release-please.yml
@@ -5,6 +5,10 @@ name: _release-please
 on:
   workflow_call:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/_release-please.yml
+++ b/.github/workflows/_release-please.yml
@@ -1,0 +1,20 @@
+# Reusable: Release Please
+# Automates versioning and changelog via conventional commits.
+name: _release-please
+
+on:
+  workflow_call:
+
+permissions: {}
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: googleapis/release-please-action@v4
+        with:
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## Summary

- Adds a reusable `_release-please` workflow that any repo in the org can call via `workflow_call`
- Uses `googleapis/release-please-action@v4` to automate versioning and changelog generation from conventional commits
- Follows the existing reusable workflow naming convention (`_` prefix)
- Expects each calling repo to provide its own `release-please-config.json` and `.release-please-manifest.json`

## Test plan

- [ ] Verify workflow syntax is valid (passed pre-commit YAML lint)
- [ ] Confirm a calling repo can reference this workflow via `uses: JacobPEvans/.github/.github/workflows/_release-please.yml@main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a reusable `_release-please` GitHub Actions workflow for versioning and changelog automation using release-please.
> 
>   - **Workflow**:
>     - Adds `_release-please.yml` to `.github/workflows` for reusable versioning and changelog automation.
>     - Utilizes `googleapis/release-please-action@v4` for processing conventional commits.
>     - Requires `release-please-config.json` and `.release-please-manifest.json` from calling repositories.
>   - **Permissions**:
>     - Grants `contents: write` and `pull-requests: write` permissions for the job.
>   - **Naming**:
>     - Follows naming convention with `_` prefix for reusable workflows.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2F.github&utm_source=github&utm_medium=referral)<sup> for 7ebe1899bd136292224b919b3bf7002018a81b7a. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->