### PR TITLE
feat(ci): centralize release-please config via runtime injection

### DIFF
--- a/.github/workflows/_release-please.yml
+++ b/.github/workflows/_release-please.yml
@@ -18,13 +18,14 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Inject central release-please config
         run: |
           curl -sfL \
             "https://raw.githubusercontent.com/JacobPEvans/.github/main/release-please-config.json" \
             -o release-please-config.json
+          python3 -c "import json,sys; json.load(open('release-please-config.json'))" || { echo 'Config download failed or invalid JSON' >&2; exit 1; }
 
       - uses: googleapis/release-please-action@v4
         with:

--- a/.github/workflows/_release-please.yml
+++ b/.github/workflows/_release-please.yml
@@ -18,6 +18,14 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      - uses: actions/checkout@v4
+
+      - name: Inject central release-please config
+        run: |
+          curl -sfL \
+            "https://raw.githubusercontent.com/JacobPEvans/.github/main/release-please-config.json" \
+            -o release-please-config.json
+
       - uses: googleapis/release-please-action@v4
         with:
           config-file: release-please-config.json

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "packages": {
+    ".": {
+      "release-type": "simple",
+      "version-file": "VERSION"
+    }
+  },
+  "versioning": "always-bump-minor",
+  "bump-minor-pre-major": true,
+  "include-v-in-tag": true,
+  "changelog-sections": [
+    {"type": "feat", "section": "Features"},
+    {"type": "fix", "section": "Bug Fixes"},
+    {"type": "perf", "section": "Performance"},
+    {"type": "breaking", "section": "Breaking Changes"},
+    {"type": "chore", "section": "Miscellaneous", "hidden": true},
+    {"type": "ci", "section": "CI", "hidden": true},
+    {"type": "docs", "section": "Documentation", "hidden": true},
+    {"type": "refactor", "section": "Refactoring", "hidden": true},
+    {"type": "test", "section": "Tests", "hidden": true}
+  ]
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,7 +7,6 @@
     }
   },
   "versioning": "always-bump-minor",
-  "bump-minor-pre-major": true,
   "include-v-in-tag": true,
   "changelog-sections": [
     {"type": "feat", "section": "Features"},


### PR DESCRIPTION
## Summary
- Add canonical `release-please-config.json` at repo root as single source of truth for all repos
- Update `_release-please.yml` reusable workflow to fetch and inject central config at runtime via curl before running release-please
- Prevents future major version bumps by enforcing `"versioning": "always-bump-minor"` centrally

## Notes
- **This PR must be merged before the 11 caller-migration PRs take effect**, as they fetch config from `.github/main`
- Per-repo `release-please-config.json` files are overwritten at runtime — no per-repo changes needed

## Test plan
- [ ] `release-please-config.json` is valid JSON with `"versioning": "always-bump-minor"`
- [ ] `_release-please.yml` has checkout step, curl step fetching central config, then release-please step
- [ ] No untrusted inputs used in run: commands (URL is hardcoded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)