### PR TITLE
fix(renovate): migrate deprecated matchPackagePrefixes to matchPackageNames

### DIFF
--- a/renovate-presets.json
+++ b/renovate-presets.json
@@ -6,7 +6,7 @@
     {
       "description": "Auto-merge JacobPEvans-owned GitHub Actions (all update types, immediate)",
       "matchDatasources": ["github-actions"],
-      "matchPackagePrefixes": ["JacobPEvans/"],
+      "matchPackageNames": ["JacobPEvans/**"],
       "automerge": true,
       "automergeType": "pr",
       "minimumReleaseAge": "0 days"
@@ -14,10 +14,10 @@
     {
       "description": "Auto-merge trusted GitHub Actions (all update types)",
       "matchDatasources": ["github-actions"],
-      "matchPackagePrefixes": [
-        "actions/",
-        "googleapis/",
-        "anthropics/"
+      "matchPackageNames": [
+        "actions/**",
+        "googleapis/**",
+        "anthropics/**"
       ],
       "automerge": true,
       "automergeType": "pr",


### PR DESCRIPTION
## Summary

- Replace `matchPackagePrefixes` (removed in Renovate v43+) with `matchPackageNames` using glob patterns
- `JacobPEvans/` → `JacobPEvans/**`, `actions/` → `actions/**`, `googleapis/` → `googleapis/**`, `anthropics/` → `anthropics/**`

## Root cause

Renovate v43+ silently ignores `matchPackagePrefixes`, causing rules to never match. PRs showed "Automerge: Disabled by config" despite `automerge: true` being set in these rules.

## Effect

All repos using `local>JacobPEvans/.github:renovate-presets` will now correctly auto-merge JacobPEvans-owned actions, trusted actions (actions/, googleapis/, anthropics/), and pre-commit hooks.

Open PRs that should pick up the fix on next Renovate run: ai-workflows #97, nix-ai #119, ansible-proxmox #70.

## Test plan

- [ ] Verify Renovate dependency dashboard shows no config migration warnings after merge
- [ ] Verify open PRs (#97, #119, #70) show "Automerge: Enabled" on next Renovate run

🤖 Generated with [Claude Code](https://claude.ai/claude-code)