### PR TITLE
feat(gemini): disable auto code review, keep on-demand via @gemini review

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,8 +1,12 @@
+have_fun: true
+
 code_review:
   comment_severity_threshold: MEDIUM
+  max_review_comments: -1
   pull_request_opened:
+    help: false
     summary: true
-    code_review: true
+    code_review: false
 
 ignore_patterns:
   - "node_modules/**"


### PR DESCRIPTION
## Summary

- Disables automatic Gemini code review on PR open (`code_review: false`) to conserve quota
- Keeps PR summaries enabled (`summary: true`) — lightweight and useful
- Manual `@gemini review` comments still trigger on-demand reviews
- Adds `have_fun: true`, `max_review_comments: -1`, `help: false`

## Test Plan

- [ ] Open a test PR — verify Gemini posts a summary but NOT a code review
- [ ] Comment `@gemini review` on the PR — verify Gemini performs a review on demand

🤖 Generated with [Claude Code](https://claude.com/claude-code)