### PR TITLE
feat: auto-merge release-please PRs

### DIFF
--- a/.github/workflows/_release-please.yml
+++ b/.github/workflows/_release-please.yml
@@ -34,7 +34,7 @@ jobs:
           manifest-file: .release-please-manifest.json
 
       - name: Enable auto-merge for release PR
-        if: steps.release.outputs.prs-created == 'true'
+        if: steps.release.outputs.prs_created == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ fromJSON(steps.release.outputs.pr).number }}

--- a/.github/workflows/_release-please.yml
+++ b/.github/workflows/_release-please.yml
@@ -28,6 +28,14 @@ jobs:
           python3 -c "import json,sys; json.load(open('release-please-config.json'))" || { echo 'Config download failed or invalid JSON' >&2; exit 1; }
 
       - uses: googleapis/release-please-action@v4
+        id: release
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      - name: Enable auto-merge for release PR
+        if: steps.release.outputs.prs-created == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ fromJSON(steps.release.outputs.pr).number }}
+        run: gh pr merge "$PR_NUMBER" --auto --squash


### PR DESCRIPTION
## Summary

- Adds `id: release` to the release-please action step to capture its outputs
- Enables GitHub native auto-merge immediately after a release PR is created
- Uses `fromJSON(steps.release.outputs.pr).number` for the PR number — sourced directly from the action that created it, eliminating any ambiguity

## Why this is safe

- `versioning: "always-bump-minor"` in the central config prevents major bumps
- GitHub auto-merge (`--auto`) only merges after all required checks pass
- PR number comes from the action's own output, not a search query

## Prerequisite

Auto-merge must be enabled in each repo's settings (Settings > General > Allow auto-merge).

## Test plan

- [ ] Merge this PR into `.github` main
- [ ] Trigger a push to `main` on any consumer repo to re-run release-please
- [ ] Confirm the resulting release-please PR has auto-merge enabled
- [ ] Verify it merges automatically after checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires up GitHub's native auto-merge to the `_release-please.yml` reusable workflow so that release PRs automatically merge once required checks pass — a neat quality-of-life improvement for the release pipeline. The approach is architecturally sound (uses the action's own output for the PR number, scoped token, correct permissions), but there's a **critical typo in the output key name** that will cause the auto-merge step to silently never execute.

**Key changes:**
- Adds `id: release` to the `googleapis/release-please-action@v4` step to capture its outputs
- Adds a new step that calls `gh pr merge --auto --squash` using the PR number from `fromJSON(steps.release.outputs.pr).number`

**Issues found:**
- `steps.release.outputs.prs-created` uses a **hyphen** — the actual release-please-action@v4 output key is `prs_created` (**underscore**). Since GitHub Actions output key lookup is exact-match, this condition will always be falsy and the step will never run. The feature is effectively a no-op as written.
- `--squash` is an unconventional merge strategy for release-please PRs; `--merge` is typically preferred to preserve the version-bump commit as the tagged release commit.

<h3>Confidence Score: 3/5</h3>

- Safe to merge without breaking anything existing, but the new auto-merge feature will not function as written due to an incorrect output key name.
- The typo (`prs-created` vs `prs_created`) means the auto-merge step is dead code — it will never fire. No existing functionality is regressed, so it's not a disaster, but the stated goal of the PR is entirely unmet until the key name is fixed.
- `.github/workflows/_release-please.yml` — specifically the `if:` condition on the new auto-merge step.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/_release-please.yml | Adds auto-merge for release-please PRs, but uses the wrong output key `prs-created` (should be `prs_created`), causing the auto-merge step to silently never execute. Also uses `--squash` which is unconventional for release-please merge commits. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant GH as GitHub (main push)
    participant WF as _release-please workflow
    participant RPA as release-please-action@v4
    participant GHCLI as gh CLI (auto-merge)
    participant PR as Release PR

    Dev->>GH: push to main
    GH->>WF: trigger workflow_call
    WF->>RPA: run with config-file & manifest-file
    RPA-->>WF: outputs: prs_created, pr (JSON), releases_created
    alt prs_created == 'true'
        WF->>GHCLI: gh pr merge PR_NUMBER --auto --squash
        GHCLI->>PR: enable auto-merge
        PR-->>GH: waits for required checks
        GH-->>PR: checks pass → auto-merge fires
    else prs_created != 'true' (or key typo present)
        WF-->>WF: step skipped, no auto-merge set
    end
```

<sub>Last reviewed commit: 1a54b55</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->