### PR TITLE
fix: replace fromJSON template expression with shell JSON parsing

### DIFF
--- a/.github/workflows/_release-please.yml
+++ b/.github/workflows/_release-please.yml
@@ -37,5 +37,7 @@ jobs:
         if: steps.release.outputs.prs_created == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ fromJSON(steps.release.outputs.pr).number }}
-        run: gh pr merge "$PR_NUMBER" --auto --squash
+          PR_JSON: ${{ steps.release.outputs.pr }}
+        run: |
+          PR_NUMBER=$(python3 -c "import json,os; print(json.loads(os.environ['PR_JSON'])['number'])")
+          gh pr merge "$PR_NUMBER" --auto --squash

--- a/.github/workflows/_release-please.yml
+++ b/.github/workflows/_release-please.yml
@@ -39,5 +39,22 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_JSON: ${{ steps.release.outputs.pr }}
         run: |
-          PR_NUMBER=$(python3 -c "import json,os; print(json.loads(os.environ['PR_JSON'])['number'])")
+          PR_NUMBER=$(python3 - << 'PY'
+          import json, os, sys
+          pr_json = os.environ.get("PR_JSON")
+          if not pr_json:
+              sys.stderr.write("Error: PR_JSON is empty or not set.\n")
+              sys.exit(1)
+          try:
+              data = json.loads(pr_json)
+          except json.JSONDecodeError as e:
+              sys.stderr.write(f"Error: Failed to parse PR_JSON: {e}\n")
+              sys.exit(1)
+          number = data.get("number")
+          if number is None:
+              sys.stderr.write("Error: 'number' field missing from PR_JSON.\n")
+              sys.exit(1)
+          print(number)
+          PY
+          )
           gh pr merge "$PR_NUMBER" --auto --squash


### PR DESCRIPTION
The `fromJSON(steps.release.outputs.pr)` expression in the env block fails with "Error reading JToken from JsonReader" when `pr` output is empty, because GitHub Actions evaluates env block expressions before checking the `if` condition.

**Fix:** Pass the raw JSON as `PR_JSON` env var and parse it in shell with Python, avoiding the template validation failure entirely.

Fixes: https://github.com/JacobPEvans/ai-workflows/actions/runs/22799631719/attempts/1

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a classic GitHub Actions footgun 🔫: `fromJSON()` in `env:` blocks gets evaluated **before** the `if:` condition is checked, so when `release-please-action` emits an empty `pr` output, the expression parser chokes and the run fails — even though the step *should* have been skipped entirely.

The fix is surgical and correct: instead of asking GitHub's expression engine to parse the JSON, the raw value is passed as a plain string env var (`PR_JSON`) and parsed in the `run:` block using Python — the same tooling already present in the rest of the workflow. By the time that Python line executes, the `if: steps.release.outputs.prs_created == 'true'` guard has already been evaluated, so `PR_JSON` is guaranteed to be populated with valid JSON.

**Key changes:**
- Removed `PR_NUMBER: ${{ fromJSON(steps.release.outputs.pr).number }}` from the `env:` block (the root cause of the failure)
- Added `PR_JSON: ${{ steps.release.outputs.pr }}` as a safe passthrough (plain string assignment, no parsing)
- Moved JSON parsing into the `run:` block via `python3 -c "import json,os; print(json.loads(os.environ['PR_JSON'])['number'])"`, which only executes when the step actually runs
- Using `os.environ['PR_JSON']` (vs. shell interpolation) is the correct approach — avoids any shell injection risk from the JSON content itself

<h3>Confidence Score: 4/5</h3>

- Safe to merge — the fix correctly addresses the root cause without introducing regressions or security concerns.
- The change is minimal and targeted, the logic is sound (moving parsing from env-eval time to run time), the `os.environ` access pattern avoids shell injection, and the Python tooling is already established in the workflow. Docking one point because there's no explicit error handling if `PR_JSON` is somehow malformed when `prs_created == 'true'` (would surface as a raw Python traceback), but the `if:` guard makes that scenario virtually impossible in practice.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/_release-please.yml | Replaces `fromJSON()` in the `env:` block (evaluated before `if` checks) with a raw string env var + Python shell parsing inside `run:`, correctly fixing the "Error reading JToken" failure on empty `pr` output. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GHA as GitHub Actions
    participant RPA as release-please-action
    participant ENV as env block
    participant Shell as run (shell)
    participant GHCLI as gh CLI

    GHA->>RPA: Execute googleapis/release-please-action@v4
    RPA-->>GHA: outputs.prs_created, outputs.pr (raw JSON)

    Note over GHA,ENV: BEFORE fix: fromJSON() evaluated here,<br/>even when if condition = false → 💥 JToken error

    GHA->>GHA: Evaluate if: prs_created == 'true'
    alt prs_created == 'true'
        GHA->>ENV: Set PR_JSON = raw JSON string (safe, no parsing)
        ENV->>Shell: Exec run block
        Shell->>Shell: python3: json.loads(PR_JSON)['number']
        Shell-->>Shell: PR_NUMBER extracted safely
        Shell->>GHCLI: gh pr merge "$PR_NUMBER" --auto --squash
        GHCLI-->>Shell: Auto-merge enabled ✅
    else prs_created != 'true'
        GHA->>GHA: Skip step entirely (PR_JSON = empty string, never parsed) ✅
    end
```

<sub>Last reviewed commit: 19cdbc2</sub>

<!-- /greptile_comment -->