### PR TITLE
feat: add mask-secrets composite action for log masking

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -36,7 +36,8 @@
     "pycache",
     "narinfo",
     "nixpkgs",
-    "Anson"
+    "Anson",
+    "pipefail"
   ],
   "ignorePaths": [
     ".git",

--- a/actions/mask-secrets/action.yml
+++ b/actions/mask-secrets/action.yml
@@ -1,0 +1,61 @@
+name: Mask Secrets
+description: Mask sensitive values (SOPS secrets and cluster IPs) in GitHub Actions logs
+
+inputs:
+  sops-file:
+    description: 'Path to SOPS-encrypted YAML file; decrypts and masks all string values'
+    required: false
+    default: ''
+  mask-pod-ips:
+    description: 'Query kubectl and mask all pod + service ClusterIPs in namespace'
+    required: false
+    default: 'false'
+  kubernetes-namespace:
+    description: 'Namespace for IP discovery'
+    required: false
+    default: 'monitoring'
+  kubernetes-context:
+    description: 'kubectl context (optional)'
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Mask SOPS secret values
+      if: inputs.sops-file != ''
+      shell: bash
+      env:
+        SOPS_FILE: ${{ inputs.sops-file }}
+      run: |
+        echo "Masking SOPS secret values..."
+        count=0
+        while IFS= read -r val; do
+          echo "::add-mask::$val"
+          count=$((count + 1))
+        done < <(sops -d "$SOPS_FILE" | yq eval '.. | strings | select(length > 4)' -)
+        echo "Masking SOPS secret values... ✓ ($count values masked)"
+
+    - name: Mask pod and service IPs
+      if: inputs.mask-pod-ips == 'true'
+      shell: bash
+      env:
+        NS: ${{ inputs.kubernetes-namespace }}
+        KUBE_CONTEXT: ${{ inputs.kubernetes-context }}
+      run: |
+        echo "Masking pod and service IPs in $NS..."
+        context_arg=""
+        if [ -n "$KUBE_CONTEXT" ]; then
+          context_arg="--context $KUBE_CONTEXT"
+        fi
+        count=0
+        while IFS= read -r ip; do
+          echo "::add-mask::$ip"
+          count=$((count + 1))
+        done < <(
+          kubectl get pods -n "$NS" $context_arg -o json \
+            | jq -r '.items[].status.podIP // empty' | sort -u
+          kubectl get svc -n "$NS" $context_arg -o json \
+            | jq -r '.items[].spec.clusterIP // empty | select(. != "None")' | sort -u
+        )
+        echo "Masking pod and service IPs in $NS... ✓ ($count IPs masked)"

--- a/actions/mask-secrets/action.yml
+++ b/actions/mask-secrets/action.yml
@@ -3,11 +3,11 @@ description: Mask sensitive values (SOPS secrets and cluster IPs) in GitHub Acti
 
 inputs:
   sops-file:
-    description: 'Path to SOPS-encrypted YAML file; decrypts and masks all string values'
+    description: 'Path to SOPS-encrypted YAML file; decrypts and masks all string values longer than 4 chars'
     required: false
     default: ''
   mask-pod-ips:
-    description: 'Query kubectl and mask all pod + service ClusterIPs in namespace'
+    description: 'Query kubectl and mask pod + service IP prefixes (first 3 octets) in namespace'
     required: false
     default: 'false'
   kubernetes-namespace:
@@ -28,43 +28,23 @@ runs:
       env:
         SOPS_FILE: ${{ inputs.sops-file }}
       run: |
-        set -euo pipefail
-        echo "Masking SOPS secret values..."
-        count=0
-        decrypted=$(sops -d "$SOPS_FILE") || { echo "::error::sops decryption failed for $SOPS_FILE"; exit 1; }
-        while IFS= read -r val; do
-          # select(length > 4) intentionally skips short values (≤4 chars) to avoid
-          # masking YAML primitives like "true", "yes", "no", "null", and short integers
-          # that would corrupt log readability if masked.
-          [ -n "$val" ] && echo "::add-mask::$val"
-          [ -n "$val" ] && count=$((count + 1))
-        done < <(echo "$decrypted" | yq eval '.. | strings | select(length > 4)' -)
-        echo "Masking SOPS secret values... ✓ ($count values masked)"
+        # select(length > 4) skips short values (≤4 chars) to avoid masking YAML
+        # primitives like "true", "yes", "no", "null" that would corrupt log readability.
+        sops -d "$SOPS_FILE" \
+          | yq eval '.. | strings | select(length > 4)' - \
+          | while IFS= read -r val; do echo "::add-mask::$val"; done
 
-    - name: Mask pod and service IPs
+    - name: Mask pod and service IP prefixes
       if: inputs.mask-pod-ips == 'true'
       shell: bash
       env:
         NS: ${{ inputs.kubernetes-namespace }}
         KUBE_CONTEXT: ${{ inputs.kubernetes-context }}
       run: |
-        set -euo pipefail
-        echo "Masking pod and service IPs in $NS..."
-        context_arg=()
-        if [ -n "$KUBE_CONTEXT" ]; then
-          context_arg=(--context "$KUBE_CONTEXT")
-        fi
-        count=0
-        pod_ips=$(kubectl get pods -n "$NS" "${context_arg[@]}" -o json \
-          | jq -r '.items[].status.podIP // empty' | sort -u) \
-          || { echo "::error::kubectl get pods failed for namespace $NS"; exit 1; }
-        svc_ips=$(kubectl get svc -n "$NS" "${context_arg[@]}" -o json \
-          | jq -r '.items[].spec.clusterIP // empty | select(. != "None")' | sort -u) \
-          || { echo "::error::kubectl get svc failed for namespace $NS"; exit 1; }
-        while IFS= read -r ip; do
-          if [ -n "$ip" ]; then
-            echo "::add-mask::$ip"
-            count=$((count + 1))
-          fi
-        done < <(printf '%s\n%s\n' "$pod_ips" "$svc_ips" | sort -u)
-        echo "Masking pod and service IPs in $NS... ✓ ($count IPs masked)"
+        # Masks only the first 3 octets (e.g. 10.42.1.x -> ***), keeping the host ID
+        # visible for debugging while hiding network topology.
+        kubectl get pods,svc -n "$NS" ${KUBE_CONTEXT:+--context "$KUBE_CONTEXT"} \
+          -o jsonpath='{range .items[*]}{.status.podIP}{"\n"}{.spec.clusterIP}{"\n"}{end}' \
+          | grep -v '^$\|None' \
+          | sed 's/\.[0-9]*$//' | sort -u \
+          | while read -r prefix; do echo "::add-mask::$prefix"; done

--- a/actions/mask-secrets/action.yml
+++ b/actions/mask-secrets/action.yml
@@ -28,12 +28,17 @@ runs:
       env:
         SOPS_FILE: ${{ inputs.sops-file }}
       run: |
+        set -euo pipefail
         echo "Masking SOPS secret values..."
         count=0
+        decrypted=$(sops -d "$SOPS_FILE") || { echo "::error::sops decryption failed for $SOPS_FILE"; exit 1; }
         while IFS= read -r val; do
-          echo "::add-mask::$val"
-          count=$((count + 1))
-        done < <(sops -d "$SOPS_FILE" | yq eval '.. | strings | select(length > 4)' -)
+          # select(length > 4) intentionally skips short values (≤4 chars) to avoid
+          # masking YAML primitives like "true", "yes", "no", "null", and short integers
+          # that would corrupt log readability if masked.
+          [ -n "$val" ] && echo "::add-mask::$val"
+          [ -n "$val" ] && count=$((count + 1))
+        done < <(echo "$decrypted" | yq eval '.. | strings | select(length > 4)' -)
         echo "Masking SOPS secret values... ✓ ($count values masked)"
 
     - name: Mask pod and service IPs
@@ -43,19 +48,23 @@ runs:
         NS: ${{ inputs.kubernetes-namespace }}
         KUBE_CONTEXT: ${{ inputs.kubernetes-context }}
       run: |
+        set -euo pipefail
         echo "Masking pod and service IPs in $NS..."
-        context_arg=""
+        context_arg=()
         if [ -n "$KUBE_CONTEXT" ]; then
-          context_arg="--context $KUBE_CONTEXT"
+          context_arg=(--context "$KUBE_CONTEXT")
         fi
         count=0
+        pod_ips=$(kubectl get pods -n "$NS" "${context_arg[@]}" -o json \
+          | jq -r '.items[].status.podIP // empty' | sort -u) \
+          || { echo "::error::kubectl get pods failed for namespace $NS"; exit 1; }
+        svc_ips=$(kubectl get svc -n "$NS" "${context_arg[@]}" -o json \
+          | jq -r '.items[].spec.clusterIP // empty | select(. != "None")' | sort -u) \
+          || { echo "::error::kubectl get svc failed for namespace $NS"; exit 1; }
         while IFS= read -r ip; do
-          echo "::add-mask::$ip"
-          count=$((count + 1))
-        done < <(
-          kubectl get pods -n "$NS" $context_arg -o json \
-            | jq -r '.items[].status.podIP // empty' | sort -u
-          kubectl get svc -n "$NS" $context_arg -o json \
-            | jq -r '.items[].spec.clusterIP // empty | select(. != "None")' | sort -u
-        )
+          if [ -n "$ip" ]; then
+            echo "::add-mask::$ip"
+            count=$((count + 1))
+          fi
+        done < <(printf '%s\n%s\n' "$pod_ips" "$svc_ips" | sort -u)
         echo "Masking pod and service IPs in $NS... ✓ ($count IPs masked)"


### PR DESCRIPTION
## Summary

- Adds reusable `actions/mask-secrets` composite action to this org-level repo
- Accepts `sops-file` input to decrypt + mask all string values from SOPS secrets
- Accepts `mask-pod-ips: 'true'` to query kubectl and mask pod/service ClusterIPs
- Logs masked counts (never values) for auditability in Actions UI

## Usage

```yaml
# Phase 1: before deploy — mask SOPS secrets
- uses: JacobPEvans/.github/actions/mask-secrets@main
  with:
    sops-file: secrets.enc.yaml

# Phase 2: after deploy — mask pod/service IPs
- uses: JacobPEvans/.github/actions/mask-secrets@main
  with:
    mask-pod-ips: 'true'
    kubernetes-namespace: monitoring
    kubernetes-context: orbstack
```

## Test plan

- [ ] Merge this PR first so `@main` ref resolves when kubernetes-monitoring PR runs E2E tests
- [ ] Verify action YAML is valid (no syntax errors)
- [ ] Check Actions run from kubernetes-monitoring PR: "Mask secrets" step logs `✓ (N values masked)`
- [ ] Confirm subsequent steps show `***` for any SOPS-managed values

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new org-level reusable composite action (`actions/mask-secrets`) that provides two log-masking modes: decrypting a SOPS-encrypted YAML and masking all extracted string values, and querying `kubectl` to mask pod/service ClusterIPs — both feeding GitHub Actions' `::add-mask::` workflow command. The action's design is clean and the inputs are well-thought-out, but there are two related logic bugs that could cause secrets to silently go unmasked.

**Key findings:**

- **🐛 Silent failure on `sops` decryption (critical):** The SOPS decryption pipeline runs inside a process substitution `< <(sops -d ... | yq ...)`. In bash (even with `-eo pipefail`), a process substitution's exit code is discarded by the parent shell — so if `sops` fails (KMS unavailable, wrong identity, missing file), the `while` loop sees EOF and exits cleanly, reporting `✓ (0 values masked)`. Subsequent steps run with zero masking applied.
- **🐛 Silent failure on `kubectl` calls (critical):** The same issue affects both `kubectl get pods` and `kubectl get svc` inside the IP-masking process substitution. A RBAC error or unreachable cluster produces a silent 0-count success.
- **🔧 Unquoted `$context_arg` (style):** The multi-word string variable should be a bash array (`context_arg=()`) to be safe against context names with spaces and to clearly signal intent.
- **📝 Undocumented `select(length > 4)` threshold (style):** The 4-character minimum is a deliberate design decision but is unexplained in the YAML, which could confuse future maintainers.

<h3>Confidence Score: 3/5</h3>

- This PR should not be merged as-is — both action steps have logic bugs that silently swallow failures, meaning the action can appear to succeed while providing zero protection.
- The concept and structure are solid (correct use of `::add-mask::`, good input design, no credential logging), but both the SOPS and kubectl branches share the same critical flaw: process substitution failures are invisible to the surrounding bash script under `-eo pipefail`. This is a correctness issue for a security-critical action, not merely a best-practice concern. Score of 3 reflects that the surrounding infrastructure is fine but the core masking logic needs a fix before this action can be trusted in production pipelines.
- actions/mask-secrets/action.yml — both `run:` blocks need error-handling for their process substitutions

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| actions/mask-secrets/action.yml | New composite action for masking SOPS secrets and kubectl IPs; has two logic bugs where process substitution failures are silently swallowed, plus a minor style issue with unquoted `$context_arg`. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant W as Workflow
    participant A as mask-secrets action
    participant S as sops
    participant Y as yq
    participant K as kubectl
    participant GH as GitHub Actions Runner

    W->>A: uses: mask-secrets@main\nwith: sops-file / mask-pod-ips

    alt sops-file input provided
        A->>S: sops -d "$SOPS_FILE"
        S-->>A: decrypted YAML (or silent fail ⚠️)
        A->>Y: yq eval '.. | strings | select(length > 4)'
        Y-->>A: string values (length > 4 only)
        loop each value
            A->>GH: echo "::add-mask::$val"
        end
        A->>W: ✓ (N values masked)
    end

    alt mask-pod-ips == 'true'
        A->>K: kubectl get pods -n $NS [--context $CTX]
        K-->>A: pod JSON (or silent fail ⚠️)
        A->>K: kubectl get svc -n $NS [--context $CTX]
        K-->>A: svc JSON (or silent fail ⚠️)
        loop each unique IP
            A->>GH: echo "::add-mask::$ip"
        end
        A->>W: ✓ (N IPs masked)
    end
```

<sub>Last reviewed commit: 95780d1</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->