### PR TITLE
feat: add mask-secrets composite action

### DIFF
--- a/actions/mask-secrets/action.yml
+++ b/actions/mask-secrets/action.yml
@@ -1,0 +1,60 @@
+name: 'Mask Secrets'
+description: 'Mask SOPS-encrypted secrets and Kubernetes pod IPs from GitHub Actions logs'
+author: 'JacobPEvans'
+
+inputs:
+  sops-file:
+    description: 'Path to SOPS-encrypted env file to decrypt and mask'
+    required: false
+    default: ''
+  mask-pod-ips:
+    description: 'If true, collect and mask all pod IPs in the cluster'
+    required: false
+    default: 'false'
+  kubernetes-namespace:
+    description: 'Kubernetes namespace to query for pod IPs'
+    required: false
+    default: 'monitoring'
+  kubernetes-context:
+    description: 'Kubernetes context to use for pod IP lookup'
+    required: false
+    default: 'orbstack'
+
+runs:
+  using: composite
+  steps:
+    - name: Mask SOPS secrets
+      if: ${{ inputs.sops-file != '' }}
+      shell: bash
+      env:
+        SOPS_FILE: ${{ inputs.sops-file }}
+      run: |
+        # Decrypt SOPS file to dotenv format, mask each value, and export to GITHUB_ENV
+        # so downstream steps have access to the secrets without them appearing in logs.
+        while IFS='=' read -r key value; do
+          # Skip comments and empty lines
+          [[ -z "$key" || "$key" =~ ^[[:space:]]*# ]] && continue
+          # Strip surrounding quotes (single or double)
+          value="${value#\"}"; value="${value%\"}"
+          value="${value#\'}"; value="${value%\'}"
+          [[ -z "$value" ]] && continue
+          echo "::add-mask::$value"
+          printf '%s=%s\n' "$key" "$value" >> "$GITHUB_ENV"
+        done < <(sops --output-type dotenv --decrypt "$SOPS_FILE")
+
+    - name: Mask cluster pod IPs
+      if: ${{ inputs.mask-pod-ips == 'true' }}
+      shell: bash
+      env:
+        K8S_CONTEXT: ${{ inputs.kubernetes-context }}
+        K8S_NAMESPACE: ${{ inputs.kubernetes-namespace }}
+      run: |
+        # Collect all pod IPs from the cluster and mask them in logs so
+        # infrastructure addresses do not appear in test output.
+        ARGS=()
+        [[ -n "$K8S_CONTEXT" ]] && ARGS+=(--context "$K8S_CONTEXT")
+        [[ -n "$K8S_NAMESPACE" ]] && ARGS+=(-n "$K8S_NAMESPACE")
+        while IFS= read -r ip; do
+          [[ -n "$ip" ]] && echo "::add-mask::$ip"
+        done < <(kubectl "${ARGS[@]}" get pods \
+          -o jsonpath='{range .items[*]}{.status.podIP}{"\n"}{end}' 2>/dev/null || true)


### PR DESCRIPTION
## Summary

- Adds a reusable composite action `actions/mask-secrets` to the shared `.github` repository
- Enables two-phase secret masking in CI workflows: SOPS secrets before deploy, cluster IPs after deploy

## Changes

- `actions/mask-secrets/action.yml` — new composite action with two steps:
  1. **Mask SOPS secrets** (if `sops-file` input provided): Decrypts a SOPS-encrypted env file using `sops --output-type dotenv --decrypt`, masks each value via `::add-mask::`, and exports all key=value pairs to `$GITHUB_ENV` so downstream steps have access without secrets appearing in logs
  2. **Mask cluster pod IPs** (if `mask-pod-ips: 'true'`): Queries `kubectl get pods` for all pod IPs in the specified namespace/context and masks each one

## Test Plan

- [ ] Action used by `kubernetes-monitoring` E2E workflow (PR #82)
- [ ] SOPS secrets masked in deploy step logs
- [ ] Cluster IPs masked in E2E test output

Related: JacobPEvans/kubernetes-monitoring#82

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a new reusable composite action `actions/mask-secrets` that handles two-phase secret masking: decrypting a SOPS-encrypted env file and masking each value from logs, and optionally querying `kubectl` to mask all pod IPs. The approach is clean and the shell logic is mostly sound, but there are four issues that need attention before this is safe to ship.

**Critical issues:**
- **Multiline secret values corrupt `$GITHUB_ENV`**: Writing secrets with `printf '%s=%s\n'` will break the env file format if any value contains a newline (SSH keys, PEM certs, JWTs are common culprits). GitHub Actions requires the heredoc delimiter syntax for multiline values. Additionally, `echo "::add-mask::$value"` with newline-containing values only masks the first line.
- **Silent SOPS decryption failure**: If SOPS fails to decrypt (missing key, wrong file path, misconfigured encryption), the process substitution yields empty output and the loop exits cleanly, reporting success with nothing masked — a security gap.
- **Silent `kubectl` failure leaves IPs unmasked**: The `2>/dev/null || true` swallows all kubectl errors. If the cluster is unreachable or RBAC denies access, zero IPs are masked and the action exits success — the caller never knows.

**Style issue:**
- **`orbstack` default is local-dev-only**: This shared action defaults `kubernetes-context` to `orbstack`, which only exists on macOS with OrbStack installed. Any CI caller that omits the input will get a silent or confusing failure.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge — contains three critical security/correctness issues (multiline secret corruption, silent SOPS failure, silent kubectl failure) plus one usability issue.
- Score of 2 reflects that the action has multiple substantive issues: (1) the multiline-value GITHUB_ENV bug is a correctness problem where secrets could leak or corrupt env parsing in ways hard to debug; (2) the silent-failure patterns on both SOPS and kubectl mean the action can report success while having done nothing (security gap); (3) the orbstack default creates CI failures for any caller in a standard runner environment. The core logic and structure are solid, and all fixes are targeted, but they must be resolved before production use.
- actions/mask-secrets/action.yml — all four issues are concentrated in this single file.

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant W as Calling Workflow
    participant A as mask-secrets action
    participant S as sops CLI
    participant K as kubectl
    participant R as GitHub Runner

    W->>A: uses: actions/mask-secrets with inputs

    alt sops-file input provided
        A->>S: decrypt SOPS file to dotenv format
        S-->>A: decrypted env lines (empty on failure)
        loop each key-value pair
            A->>R: add-mask workflow command
            A->>R: append to GITHUB_ENV
        end
    end

    alt mask-pod-ips is true
        A->>K: get pods with podIP jsonpath query
        K-->>A: IP list (or empty if kubectl fails silently)
        loop each IP address
            A->>R: add-mask workflow command
        end
    end

    R-->>W: Downstream steps run with masked outputs
```

<sub>Last reviewed commit: c7320ef</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->