### PR TITLE
fix: use yq v4 select(type==!!str) instead of jq strings alias

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -37,7 +37,8 @@
     "narinfo",
     "nixpkgs",
     "Anson",
-    "pipefail"
+    "pipefail",
+    "mikefarah"
   ],
   "ignorePaths": [
     ".git",

--- a/actions/mask-secrets/action.yml
+++ b/actions/mask-secrets/action.yml
@@ -30,8 +30,10 @@ runs:
       run: |
         # select(length > 4) skips short values (≤4 chars) to avoid masking YAML
         # primitives like "true", "yes", "no", "null" that would corrupt log readability.
+        # yq (mikefarah/yq v4) uses select(type == "!!str") to filter strings;
+        # the jq-style "strings" alias is not supported in yq v4.
         sops -d "$SOPS_FILE" \
-          | yq eval '.. | strings | select(length > 4)' - \
+          | yq eval '.. | select(type == "!!str") | select(length > 4)' - \
           | while IFS= read -r val; do echo "::add-mask::$val"; done
 
     - name: Mask pod and service IP prefixes


### PR DESCRIPTION
## Summary

- `yq eval '.. | strings | select(length > 4)'` fails with mikefarah/yq v4 because `strings` is a jq-only type coercion builtin not supported by yq v4
- Fix: replace with `select(type == "!!str")` which is the correct yq v4 syntax for selecting string-typed YAML nodes
- Also adds `mikefarah` to the cspell word list

## Changes

- `actions/mask-secrets/action.yml`: replace `strings` with `select(type == "!!str")` in yq expression
- `.cspell.json`: add `mikefarah` to allowed words

## Test Plan

- [ ] CI passes in kubernetes-monitoring PR #82 (the consumer of this action)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This is a targeted compatibility fix for `mikefarah/yq` v4. The previous expression used `strings`, a jq-style type-coercion alias that yq v4 does not support, causing the secret-masking step to silently fail or error out. The fix swaps it for `select(type == "!!str")`, which is the idiomatic yq v4 way to filter YAML nodes by their tag type, preserving the existing `select(length > 4)` guard and pipeline structure exactly. A companion cspell entry keeps the spell checker happy with the new code comment.

- **`actions/mask-secrets/action.yml`**: `.. | strings | select(length > 4)` → `.. | select(type == "!!str") | select(length > 4)` — correct yq v4 syntax, semantically equivalent to the original intent.
- **`.cspell.json`**: `mikefarah` added to the word allow-list to satisfy the spell checker for the new explanatory comment.
- The fix is minimal, well-commented, and does not alter any surrounding logic.

<h3>Confidence Score: 5/5</h3>

- Safe to merge — the change is a single-line bug fix with correct yq v4 syntax and no side effects.
- The replacement expression `select(type == "!!str")` is the documented yq v4 idiom for matching YAML string nodes, and the rest of the pipeline is untouched. The cspell change is trivially correct. No new logic paths, no new dependencies, no risk of secret leakage introduced.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| actions/mask-secrets/action.yml | Replaces jq-only `strings` builtin with yq v4-compatible `select(type == "!!str")` filter; logic and pipeline ordering are correct, and added inline comment improves clarity. |
| .cspell.json | Adds `mikefarah` to the cspell allow-list so the GitHub username referenced in the new comment doesn't trip the spell checker. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["sops -d SOPS_FILE"] -->|"decrypted YAML stream"| B["yq eval recurse all nodes"]
    B --> C{"node type is str?"}
    C -- No --> D["Drop node\n(int / bool / null / etc.)"]
    C -- Yes --> E{"length greater than 4?"}
    E -- No --> F["Drop short string\n('yes', 'no', 'null', 'true')"]
    E -- Yes --> G["Emit secret value"]
    G --> H["while IFS= read -r val"]
    H --> I["echo add-mask value"]
    I --> J["Value masked in GitHub Actions logs"]
```

<sub>Last reviewed commit: 164173f</sub>

<!-- /greptile_comment -->