### PR TITLE
feat: add daily repo health audit agentic workflow

### DIFF
--- a/.github/workflows/repo-health-audit.md
+++ b/.github/workflows/repo-health-audit.md
@@ -26,7 +26,7 @@ safe-outputs:
     close-older-issues: true
 
   add-labels:
-    allowed: ["type:ci", "type:security", "priority:critical", "priority:high", "priority:medium", "priority:low"]
+    allowed: ["type:ci", "type:chore", "type:security", "priority:critical", "priority:high", "priority:medium", "priority:low"]
     max: 16
 
   close-issue:

--- a/.github/workflows/repo-health-audit.md
+++ b/.github/workflows/repo-health-audit.md
@@ -1,9 +1,9 @@
 ---
 description: "Daily repository health audit - CI failures, security alerts, stale PRs, policy violations"
+engine: copilot
 
 on:
-  schedule:
-    - cron: '0 5 * * *'
+  schedule: daily
   workflow_dispatch:
 
 imports:

--- a/.github/workflows/repo-health-audit.md
+++ b/.github/workflows/repo-health-audit.md
@@ -19,14 +19,14 @@ tools:
 safe-outputs:
   create-issue:
     title-prefix: "[health-audit] "
-    labels: ["ai:created", "type:chore"]
+    labels: ["ai:created"]
     group: true
     max: 8
     expires: 7d
     close-older-issues: true
 
   add-labels:
-    allowed: ["type:ci", "type:chore", "type:security", "priority:critical", "priority:high", "priority:medium", "priority:low"]
+    allowed: ["type:ci", "type:chore", "type:security", "priority:critical", "priority:high", "priority:medium", "priority:low", "size:xs"]
     max: 16
 
   close-issue:
@@ -54,7 +54,7 @@ Create a parent issue titled `[health-audit] Daily Health Audit - YYYY-MM-DD` (r
 The body should contain a summary table with one row per category, showing Pass/Fail and a brief note.
 Populate this after gathering findings.
 
-Labels: `ai:created`, `type:chore`
+Labels: `ai:created`, `type:chore`, `priority:low`, `size:xs`
 
 ### Step 2: Audit Each Category
 
@@ -63,13 +63,14 @@ the parent. If it has no findings, mark it as Pass in the summary table.
 
 #### Category: Failed CI on Main
 
-Check workflow runs on the `main` branch over the last 7 days. Look for any runs with `failure` or `cancelled` status.
+Check workflow runs on the `main` branch over the last 7 days. In the GitHub Actions API, look for runs where `status` is
+`completed` and `conclusion` is `failure` or `cancelled`.
 
 If findings exist:
 
 - Create sub-issue: `[health-audit] Failed CI on Main`
 - List each failed workflow by name, run ID, and failure date
-- Apply labels: `type:ci`, and the appropriate priority:
+- Apply labels: `type:ci`, `size:xs`, and the appropriate priority:
   - `priority:high` if any failure occurred in the last 24 hours
   - `priority:medium` otherwise
 
@@ -84,7 +85,7 @@ If findings exist:
 
 - Create sub-issue: `[health-audit] Failed CI on Open PRs`
 - List each PR by number, title, failing check names, and how long it has been failing
-- Apply labels: `type:ci`, `priority:medium`
+- Apply labels: `type:ci`, `priority:medium`, `size:xs`
 
 #### Category: CodeQL and Security Scanning Alerts
 
@@ -94,7 +95,7 @@ If findings exist:
 
 - Create sub-issue: `[health-audit] Security Scanning Alerts`
 - List alert titles, severity, and affected file/line where available
-- Apply labels: `type:security`, and:
+- Apply labels: `type:security`, `size:xs`, and:
   - `priority:critical` if any critical or high severity alerts exist
   - `priority:medium` if only medium/low severity alerts exist
 
@@ -106,7 +107,7 @@ If findings exist:
 
 - Create sub-issue: `[health-audit] Dependency Security Alerts`
 - List each vulnerable dependency with severity and fix version if known
-- Apply labels: `type:security`, and:
+- Apply labels: `type:security`, `size:xs`, and:
   - `priority:critical` if any critical severity alerts
   - `priority:high` if any high severity alerts
   - `priority:medium` otherwise
@@ -119,7 +120,7 @@ If findings exist:
 
 - Create sub-issue: `[health-audit] Secret Scanning Alerts`
 - List each alert type (do NOT include actual secret values)
-- Apply labels: `type:security`, `priority:critical`
+- Apply labels: `type:security`, `priority:critical`, `size:xs`
 
 #### Category: Stale Pull Requests
 
@@ -134,7 +135,7 @@ If findings exist:
 
 - Create sub-issue: `[health-audit] Stale Pull Requests`
 - List each stale PR by number, title, author, and days since last activity
-- Apply labels: `type:chore`, `priority:low`
+- Apply labels: `type:chore`, `priority:low`, `size:xs`
 
 #### Category: Failed Scheduled Workflows
 
@@ -147,7 +148,7 @@ If findings exist:
 
 - Create sub-issue: `[health-audit] Failed Scheduled Workflows`
 - List each affected workflow by name and last run status/date
-- Apply labels: `type:ci`, `priority:high`
+- Apply labels: `type:ci`, `priority:high`, `size:xs`
 
 ### Step 3: Finalize Parent Issue
 

--- a/.github/workflows/repo-health-audit.md
+++ b/.github/workflows/repo-health-audit.md
@@ -1,0 +1,178 @@
+---
+description: "Daily repository health audit - CI failures, security alerts, stale PRs, policy violations"
+
+on:
+  schedule:
+    - cron: '0 5 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+  actions: read
+  security-events: read
+
+tools:
+  github:
+
+safe-outputs:
+  create-issue:
+    title-prefix: "[health-audit] "
+    labels: ["ai:created", "type:chore"]
+    group: true
+    max: 8
+    expires: 7d
+    close-older-issues: true
+
+  add-labels:
+    allowed: ["type:ci", "type:security", "priority:critical", "priority:high", "priority:medium", "priority:low"]
+    max: 8
+
+  close-issue:
+    required-title-prefix: "[health-audit] "
+    required-labels: ["ai:created"]
+    max: 10
+    state-reason: "completed"
+
+timeout-minutes: 15
+---
+
+# Repo Health Audit
+
+You are a repository health auditor. Your job is to inspect this repository for problems
+and create a structured report as GitHub Issues.
+
+## Instructions
+
+Today's date is available from the workflow run timestamp. Use it to label the parent issue.
+
+### Step 1: Create Parent Issue
+
+Create a parent issue titled `[health-audit] Daily Health Audit - YYYY-MM-DD` (replace with today's date).
+
+The body should contain a summary table with one row per category, showing Pass/Fail and a brief note.
+Populate this after gathering findings.
+
+Labels: `ai:created`, `type:chore`
+
+### Step 2: Audit Each Category
+
+For each category below, gather findings. If a category has findings, create a sub-issue linked to
+the parent. If it has no findings, mark it as Pass in the summary table.
+
+#### Category: Failed CI on Main
+
+Check workflow runs on the `main` branch over the last 7 days. Look for any runs with `failure` or `cancelled` status.
+
+If findings exist:
+
+- Create sub-issue: `[health-audit] Failed CI on Main`
+- List each failed workflow by name, run ID, and failure date
+- Apply labels: `type:ci`, and the appropriate priority:
+  - `priority:high` if any failure occurred in the last 24 hours
+  - `priority:medium` otherwise
+
+#### Category: Failed CI on Open PRs
+
+Check all open pull requests. For each PR, inspect the most recent check suite. Flag PRs where checks
+have been failing for more than 48 hours.
+
+Exclude: draft PRs, PRs authored by bots (Renovate, Dependabot).
+
+If findings exist:
+
+- Create sub-issue: `[health-audit] Failed CI on Open PRs`
+- List each PR by number, title, failing check names, and how long it has been failing
+- Apply labels: `type:ci`, `priority:medium`
+
+#### Category: CodeQL and Security Scanning Alerts
+
+Check open code scanning alerts (CodeQL). Group by severity: critical, high, medium, low.
+
+If findings exist:
+
+- Create sub-issue: `[health-audit] Security Scanning Alerts`
+- List alert titles, severity, and affected file/line where available
+- Apply labels: `type:security`, and:
+  - `priority:critical` if any critical or high severity alerts exist
+  - `priority:medium` if only medium/low severity alerts exist
+
+#### Category: Dependency Security Alerts
+
+Check for open Dependabot or Renovate vulnerability alerts. Include package name, severity, and CVE if available.
+
+If findings exist:
+
+- Create sub-issue: `[health-audit] Dependency Security Alerts`
+- List each vulnerable dependency with severity and fix version if known
+- Apply labels: `type:security`, and:
+  - `priority:critical` if any critical severity alerts
+  - `priority:high` if any high severity alerts
+  - `priority:medium` otherwise
+
+#### Category: Secret Scanning Alerts
+
+Check for open secret scanning alerts.
+
+If findings exist:
+
+- Create sub-issue: `[health-audit] Secret Scanning Alerts`
+- List each alert type (do NOT include actual secret values)
+- Apply labels: `type:security`, `priority:critical`
+
+#### Category: Stale Pull Requests
+
+Find open pull requests that meet all of the following:
+
+- Have been open for more than 7 days
+- Have had no activity (comments, commits, review events) in the last 7 days
+- Are not drafts
+- Are not authored by bots (Renovate, Dependabot, copilot)
+
+If findings exist:
+
+- Create sub-issue: `[health-audit] Stale Pull Requests`
+- List each stale PR by number, title, author, and days since last activity
+- Apply labels: `type:ci`, `priority:low`
+
+#### Category: Failed Scheduled Workflows
+
+Check all workflows configured with `schedule` triggers. Find any that have failed or not run in the
+last 25 hours (to account for timing variance in daily schedules).
+
+Exclude this workflow itself from the check.
+
+If findings exist:
+
+- Create sub-issue: `[health-audit] Failed Scheduled Workflows`
+- List each affected workflow by name and last run status/date
+- Apply labels: `type:ci`, `priority:high`
+
+### Step 3: Finalize Parent Issue
+
+Update the parent issue body with the complete summary table:
+
+| Category | Status | Details |
+| --- | --- | --- |
+| Failed CI on Main | ✅ Pass / ❌ Fail | brief note |
+| Failed CI on Open PRs | ✅ Pass / ❌ Fail | brief note |
+| CodeQL / Security Scanning | ✅ Pass / ❌ Fail | brief note |
+| Dependency Security | ✅ Pass / ❌ Fail | brief note |
+| Secret Scanning | ✅ Pass / ❌ Fail | brief note |
+| Stale Pull Requests | ✅ Pass / ❌ Fail | brief note |
+| Failed Scheduled Workflows | ✅ Pass / ❌ Fail | brief note |
+
+If ALL categories pass, still create the parent issue with the all-clear table — it serves as an audit trail.
+
+### Step 4: Close Empty Sub-Issues
+
+If you created any sub-issues that ended up with no findings (due to race conditions or data changing
+during the audit), close them with state-reason `completed`.
+
+### Notes
+
+- Do not include raw secret values in any issue body
+- Issue titles must use the `[health-audit]` prefix as configured
+- The `close-older-issues: true` setting auto-closes the previous audit issue when this one is created
+- Keep sub-issue bodies concise but actionable — each finding should have enough information to act on it

--- a/.github/workflows/repo-health-audit.md
+++ b/.github/workflows/repo-health-audit.md
@@ -8,7 +8,7 @@ on:
 
 permissions:
   contents: read
-  issues: read
+  issues: write
   pull-requests: read
   actions: read
   security-events: read
@@ -27,7 +27,7 @@ safe-outputs:
 
   add-labels:
     allowed: ["type:ci", "type:security", "priority:critical", "priority:high", "priority:medium", "priority:low"]
-    max: 8
+    max: 16
 
   close-issue:
     required-title-prefix: "[health-audit] "
@@ -134,7 +134,7 @@ If findings exist:
 
 - Create sub-issue: `[health-audit] Stale Pull Requests`
 - List each stale PR by number, title, author, and days since last activity
-- Apply labels: `type:ci`, `priority:low`
+- Apply labels: `type:chore`, `priority:low`
 
 #### Category: Failed Scheduled Workflows
 

--- a/.github/workflows/repo-health-audit.md
+++ b/.github/workflows/repo-health-audit.md
@@ -6,6 +6,9 @@ on:
     - cron: '0 5 * * *'
   workflow_dispatch:
 
+imports:
+  - shared/repo-health-audit-config.md
+
 permissions:
   contents: read
   issues: write
@@ -13,167 +16,9 @@ permissions:
   actions: read
   security-events: read
 
-tools:
-  github:
-
-safe-outputs:
-  create-issue:
-    title-prefix: "[health-audit] "
-    labels: ["ai:created"]
-    group: true
-    max: 8
-    expires: 7d
-    close-older-issues: true
-
-  add-labels:
-    allowed: ["type:ci", "type:chore", "type:security", "priority:critical", "priority:high", "priority:medium", "priority:low", "size:xs"]
-    max: 16
-
-  close-issue:
-    required-title-prefix: "[health-audit] "
-    required-labels: ["ai:created"]
-    max: 10
-    state-reason: "completed"
-
 timeout-minutes: 15
 ---
 
 # Repo Health Audit
 
-You are a repository health auditor. Your job is to inspect this repository for problems
-and create a structured report as GitHub Issues.
-
-## Instructions
-
-Today's date is available from the workflow run timestamp. Use it to label the parent issue.
-
-### Step 1: Create Parent Issue
-
-Create a parent issue titled `[health-audit] Daily Health Audit - YYYY-MM-DD` (replace with today's date).
-
-The body should contain a summary table with one row per category, showing Pass/Fail and a brief note.
-Populate this after gathering findings.
-
-Labels: `ai:created`, `type:chore`, `priority:low`, `size:xs`
-
-### Step 2: Audit Each Category
-
-For each category below, gather findings. If a category has findings, create a sub-issue linked to
-the parent. If it has no findings, mark it as Pass in the summary table.
-
-#### Category: Failed CI on Main
-
-Check workflow runs on the `main` branch over the last 7 days. In the GitHub Actions API, look for runs where `status` is
-`completed` and `conclusion` is `failure` or `cancelled`.
-
-If findings exist:
-
-- Create sub-issue: `[health-audit] Failed CI on Main`
-- List each failed workflow by name, run ID, and failure date
-- Apply labels: `type:ci`, `size:xs`, and the appropriate priority:
-  - `priority:high` if any failure occurred in the last 24 hours
-  - `priority:medium` otherwise
-
-#### Category: Failed CI on Open PRs
-
-Check all open pull requests. For each PR, inspect the most recent check suite. Flag PRs where checks
-have been failing for more than 48 hours.
-
-Exclude: draft PRs, PRs authored by bots (Renovate, Dependabot).
-
-If findings exist:
-
-- Create sub-issue: `[health-audit] Failed CI on Open PRs`
-- List each PR by number, title, failing check names, and how long it has been failing
-- Apply labels: `type:ci`, `priority:medium`, `size:xs`
-
-#### Category: CodeQL and Security Scanning Alerts
-
-Check open code scanning alerts (CodeQL). Group by severity: critical, high, medium, low.
-
-If findings exist:
-
-- Create sub-issue: `[health-audit] Security Scanning Alerts`
-- List alert titles, severity, and affected file/line where available
-- Apply labels: `type:security`, `size:xs`, and:
-  - `priority:critical` if any critical or high severity alerts exist
-  - `priority:medium` if only medium/low severity alerts exist
-
-#### Category: Dependency Security Alerts
-
-Check for open Dependabot or Renovate vulnerability alerts. Include package name, severity, and CVE if available.
-
-If findings exist:
-
-- Create sub-issue: `[health-audit] Dependency Security Alerts`
-- List each vulnerable dependency with severity and fix version if known
-- Apply labels: `type:security`, `size:xs`, and:
-  - `priority:critical` if any critical severity alerts
-  - `priority:high` if any high severity alerts
-  - `priority:medium` otherwise
-
-#### Category: Secret Scanning Alerts
-
-Check for open secret scanning alerts.
-
-If findings exist:
-
-- Create sub-issue: `[health-audit] Secret Scanning Alerts`
-- List each alert type (do NOT include actual secret values)
-- Apply labels: `type:security`, `priority:critical`, `size:xs`
-
-#### Category: Stale Pull Requests
-
-Find open pull requests that meet all of the following:
-
-- Have been open for more than 7 days
-- Have had no activity (comments, commits, review events) in the last 7 days
-- Are not drafts
-- Are not authored by bots (Renovate, Dependabot, copilot)
-
-If findings exist:
-
-- Create sub-issue: `[health-audit] Stale Pull Requests`
-- List each stale PR by number, title, author, and days since last activity
-- Apply labels: `type:chore`, `priority:low`, `size:xs`
-
-#### Category: Failed Scheduled Workflows
-
-Check all workflows configured with `schedule` triggers. Find any that have failed or not run in the
-last 25 hours (to account for timing variance in daily schedules).
-
-Exclude this workflow itself from the check.
-
-If findings exist:
-
-- Create sub-issue: `[health-audit] Failed Scheduled Workflows`
-- List each affected workflow by name and last run status/date
-- Apply labels: `type:ci`, `priority:high`, `size:xs`
-
-### Step 3: Finalize Parent Issue
-
-Update the parent issue body with the complete summary table:
-
-| Category | Status | Details |
-| --- | --- | --- |
-| Failed CI on Main | ✅ Pass / ❌ Fail | brief note |
-| Failed CI on Open PRs | ✅ Pass / ❌ Fail | brief note |
-| CodeQL / Security Scanning | ✅ Pass / ❌ Fail | brief note |
-| Dependency Security | ✅ Pass / ❌ Fail | brief note |
-| Secret Scanning | ✅ Pass / ❌ Fail | brief note |
-| Stale Pull Requests | ✅ Pass / ❌ Fail | brief note |
-| Failed Scheduled Workflows | ✅ Pass / ❌ Fail | brief note |
-
-If ALL categories pass, still create the parent issue with the all-clear table — it serves as an audit trail.
-
-### Step 4: Close Empty Sub-Issues
-
-If you created any sub-issues that ended up with no findings (due to race conditions or data changing
-during the audit), close them with state-reason `completed`.
-
-### Notes
-
-- Do not include raw secret values in any issue body
-- Issue titles must use the `[health-audit]` prefix as configured
-- The `close-older-issues: true` setting auto-closes the previous audit issue when this one is created
-- Keep sub-issue bodies concise but actionable — each finding should have enough information to act on it
+{{#import shared/repo-health-audit-prompt.md}}

--- a/.github/workflows/shared/repo-health-audit-config.md
+++ b/.github/workflows/shared/repo-health-audit-config.md
@@ -1,0 +1,24 @@
+---
+tools:
+  github:
+    toolsets: [default]
+
+safe-outputs:
+  create-issue:
+    title-prefix: "[health-audit] "
+    labels: ["ai:created"]
+    group: true
+    max: 8
+    expires: 7d
+    close-older-issues: true
+
+  add-labels:
+    allowed: ["type:ci", "type:chore", "type:security", "priority:critical", "priority:high", "priority:medium", "priority:low", "size:xs"]
+    max: 16
+
+  close-issue:
+    required-title-prefix: "[health-audit] "
+    required-labels: ["ai:created"]
+    max: 10
+    state-reason: "completed"
+---

--- a/.github/workflows/shared/repo-health-audit-prompt.md
+++ b/.github/workflows/shared/repo-health-audit-prompt.md
@@ -1,0 +1,139 @@
+# Repo Health Audit Prompt
+
+You are a repository health auditor. Your job is to inspect this repository for problems
+and create a structured report as GitHub Issues.
+
+## Instructions
+
+Today's date is available from the workflow run timestamp. Use it to label the parent issue.
+
+### Step 1: Create Parent Issue
+
+Create a parent issue titled `[health-audit] Daily Health Audit - YYYY-MM-DD` (replace with today's date).
+
+The body should contain a summary table with one row per category, showing Pass/Fail and a brief note.
+Populate this after gathering findings.
+
+Labels: `ai:created`, `type:chore`, `priority:low`, `size:xs`
+
+### Step 2: Audit Each Category
+
+For each category below, gather findings. If a category has findings, create a sub-issue linked to
+the parent. If it has no findings, mark it as Pass in the summary table.
+
+#### Category: Failed CI on Main
+
+Check workflow runs on the `main` branch over the last 7 days. In the GitHub Actions API, look for runs where `status` is
+`completed` and `conclusion` is `failure` or `cancelled`.
+
+If findings exist:
+
+- Create sub-issue: `[health-audit] Failed CI on Main`
+- List each failed workflow by name, run ID, and failure date
+- Apply labels: `type:ci`, `size:xs`, and the appropriate priority:
+  - `priority:high` if any failure occurred in the last 24 hours
+  - `priority:medium` otherwise
+
+#### Category: Failed CI on Open PRs
+
+Check all open pull requests. For each PR, inspect the most recent check suite. Flag PRs where checks
+have been failing for more than 48 hours.
+
+Exclude: draft PRs, PRs authored by bots (Renovate, Dependabot).
+
+If findings exist:
+
+- Create sub-issue: `[health-audit] Failed CI on Open PRs`
+- List each PR by number, title, failing check names, and how long it has been failing
+- Apply labels: `type:ci`, `priority:medium`, `size:xs`
+
+#### Category: CodeQL and Security Scanning Alerts
+
+Check open code scanning alerts (CodeQL). Group by severity: critical, high, medium, low.
+
+If findings exist:
+
+- Create sub-issue: `[health-audit] Security Scanning Alerts`
+- List alert titles, severity, and affected file/line where available
+- Apply labels: `type:security`, `size:xs`, and:
+  - `priority:critical` if any critical or high severity alerts exist
+  - `priority:medium` if only medium/low severity alerts exist
+
+#### Category: Dependency Security Alerts
+
+Check for open Dependabot or Renovate vulnerability alerts. Include package name, severity, and CVE if available.
+
+If findings exist:
+
+- Create sub-issue: `[health-audit] Dependency Security Alerts`
+- List each vulnerable dependency with severity and fix version if known
+- Apply labels: `type:security`, `size:xs`, and:
+  - `priority:critical` if any critical severity alerts
+  - `priority:high` if any high severity alerts
+  - `priority:medium` otherwise
+
+#### Category: Secret Scanning Alerts
+
+Check for open secret scanning alerts.
+
+If findings exist:
+
+- Create sub-issue: `[health-audit] Secret Scanning Alerts`
+- List each alert type (do NOT include actual secret values)
+- Apply labels: `type:security`, `priority:critical`, `size:xs`
+
+#### Category: Stale Pull Requests
+
+Find open pull requests that meet all of the following:
+
+- Have been open for more than 7 days
+- Have had no activity (comments, commits, review events) in the last 7 days
+- Are not drafts
+- Are not authored by bots (Renovate, Dependabot, copilot)
+
+If findings exist:
+
+- Create sub-issue: `[health-audit] Stale Pull Requests`
+- List each stale PR by number, title, author, and days since last activity
+- Apply labels: `type:chore`, `priority:low`, `size:xs`
+
+#### Category: Failed Scheduled Workflows
+
+Check all workflows configured with `schedule` triggers. Find any that have failed or not run in the
+last 25 hours (to account for timing variance in daily schedules).
+
+Exclude this workflow itself from the check.
+
+If findings exist:
+
+- Create sub-issue: `[health-audit] Failed Scheduled Workflows`
+- List each affected workflow by name and last run status/date
+- Apply labels: `type:ci`, `priority:high`, `size:xs`
+
+### Step 3: Finalize Parent Issue
+
+Update the parent issue body with the complete summary table:
+
+| Category | Status | Details |
+| --- | --- | --- |
+| Failed CI on Main | ✅ Pass / ❌ Fail | brief note |
+| Failed CI on Open PRs | ✅ Pass / ❌ Fail | brief note |
+| CodeQL / Security Scanning | ✅ Pass / ❌ Fail | brief note |
+| Dependency Security | ✅ Pass / ❌ Fail | brief note |
+| Secret Scanning | ✅ Pass / ❌ Fail | brief note |
+| Stale Pull Requests | ✅ Pass / ❌ Fail | brief note |
+| Failed Scheduled Workflows | ✅ Pass / ❌ Fail | brief note |
+
+If ALL categories pass, still create the parent issue with the all-clear table — it serves as an audit trail.
+
+### Step 4: Close Empty Sub-Issues
+
+If you created any sub-issues that ended up with no findings (due to race conditions or data changing
+during the audit), close them with state-reason `completed`.
+
+### Notes
+
+- Do not include raw secret values in any issue body
+- Issue titles must use the `[health-audit]` prefix as configured
+- The `close-older-issues: true` setting auto-closes the previous audit issue when this one is created
+- Keep sub-issue bodies concise but actionable — each finding should have enough information to act on it

--- a/cchk.toml
+++ b/cchk.toml
@@ -15,5 +15,6 @@ allow_branch_types = [
   "release",
   "chore",
   "claude",
+  "copilot",
 ]
 allow_branch_names = ["main", "develop"]


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/repo-health-audit.md` — a GitHub Copilot agentic workflow that runs daily at 5am UTC
- Audits 7 categories: failed CI on main, failed CI on open PRs, CodeQL alerts, dependency security, secret scanning, stale PRs, and failed scheduled workflows
- Creates a parent GitHub Issue with summary table plus sub-issues per category with appropriate `type:ci`/`type:security` and priority labels
- Deduplication via `close-older-issues: true`, `expires: 7d`, and `group: true`
- Designed as a reusable template other repos can import via `gh aw add`

## Remaining steps (follow-up)

- [ ] Update `cchk.toml` to add `"copilot"` to `allow_branch_types`
- [ ] Run `gh aw compile` to generate `.lock.yml` and commit alongside the `.md`

## Test plan

- [ ] After merge, trigger via `workflow_dispatch` in Actions tab
- [ ] Verify parent issue created with `[health-audit]` prefix and `ai:created` label
- [ ] Verify category sub-issues linked as children with correct labels
- [ ] Run again manually — verify old audit is closed, new one created

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a GitHub Copilot agentic workflow (`.github/workflows/repo-health-audit.md`) that runs daily at 5am UTC to audit repo health across 7 categories — CI failures, CodeQL/dependency/secret security alerts, stale PRs, and failed scheduled workflows — then files a parent GitHub Issue plus per-category sub-issues with appropriate labels. The overall design is solid and fits well into the repo's existing label taxonomy and agentic tooling patterns.

**Key findings:**
- 🚨 **Critical — `issues: read` must be `issues: write`**: The entire point of this workflow is to create, label, and close issues, but the `permissions` block only grants read access to issues. Every write operation (`create-issue`, `add-labels`, `close-issue`) will receive a 403 from the GitHub API at runtime, causing the workflow to fail completely.
- ⚠️ **`add-labels.max: 8` is undersized**: In a worst-case run where all 7 categories have findings, each sub-issue needs two `add-labels` calls (one `type:*` + one `priority:*`), totalling up to 14 operations. The current cap of 8 means the last few sub-issues would be silently left without their triage labels.
- 💡 **Stale PRs labeled `type:ci`**: Semantically a minor mismatch — stale PRs are more of a process/housekeeping concern than a CI concern. Consider `type:chore` instead.
- 📝 **Acknowledged follow-ups**: The PR description correctly notes that `cchk.toml` needs a `"copilot"` branch type added and that `gh aw compile` must be run to generate the companion `.lock.yml` before the workflow is truly operational.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge as-is — the `issues: read` permission bug will cause the workflow to 403 on every write operation, making it completely non-functional at runtime.
- The critical `issues: read` → `issues: write` permission mismatch is a guaranteed runtime failure. The workflow would trigger on schedule, do all its read-side auditing correctly, and then fail on the very first `create-issue` call, producing no output whatsoever. That single blocker, plus the `add-labels.max` undersizing that would silently mis-label issues in full-failure scenarios, drops confidence significantly.
- `.github/workflows/repo-health-audit.md` — fix `issues: read` → `issues: write` and bump `add-labels.max` before merging.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/repo-health-audit.md | New GitHub Copilot agentic workflow for daily repo health auditing across 7 categories; has a critical `issues: read` → `issues: write` permission bug that will prevent all issue creation/labeling/closing, and an `add-labels.max: 8` cap that's insufficient for worst-case runs (up to 14 ops needed). |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant S as Scheduler (5am UTC)
    participant A as Copilot Agent
    participant GH as GitHub API
    participant I as Issues

    S->>A: Trigger workflow (schedule / workflow_dispatch)
    A->>GH: Read workflow runs on main (actions: read)
    A->>GH: Read open PR check suites (pull-requests: read)
    A->>GH: Read CodeQL / code scanning alerts (security-events: read)
    A->>GH: Read Dependabot vulnerability alerts (security-events: read)
    A->>GH: Read secret scanning alerts (security-events: read)
    A->>GH: Read open PRs for staleness check (pull-requests: read)
    A->>GH: Read scheduled workflow run history (actions: read)

    Note over A: Collate findings per category

    A->>I: create-issue → Parent "[health-audit] Daily Health Audit - DATE"
    Note over A,I: close-older-issues: true closes previous audit issue

    loop For each failing category (up to 7)
        A->>I: create-issue → Sub-issue "[health-audit] <Category>"
        A->>I: add-labels → type:ci / type:security + priority:*
    end

    A->>I: Update parent issue body with summary table

    opt Empty sub-issues (race condition)
        A->>I: close-issue (state-reason: completed)
    end
```

<sub>Last reviewed commit: de0a5c3</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->