### PR TITLE
chore(ci): add environment: automation to secret-using workflows

### DIFF
--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    environment: automation
     # permissions for GITHUB_TOKEN (used by EndBug/label-sync on this repo only).
     # Cross-repo operations use GH_PAT_WORKFLOW_DISPATCH PAT instead.
     permissions:


### PR DESCRIPTION
## Summary

- Adds `environment: automation` to the `sync` job in `label-sync.yml`

This scopes secret access (`GH_PAT_WORKFLOW_DISPATCH`) to the named `automation` environment, satisfying zizmor's `secrets-outside-env` lint rule.

The `automation` environment was pre-created via API before this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a single line — `environment: automation` — to the `sync` job in `label-sync.yml`, scoping PAT secret access to a named GitHub Actions environment and satisfying zizmor's `secrets-outside-env` static analysis rule. The change is minimal, correct, and well-motivated.

**Key changes:**
- `environment: automation` added at the job level (line 12), which is the correct place in the GitHub Actions YAML schema — not at the workflow or step level.
- The `GH_PAT_WORKFLOW_DISPATCH` secret (used in Step 2 to clone labels across repos) is now scoped to the `automation` environment context. Repository-level secrets remain accessible to environment-scoped jobs, so no secret migration is required for the workflow to continue functioning.
- The `automation` environment was pre-provisioned before this PR, so the workflow should not encounter a missing-environment error on its next run.
- **One thing worth keeping in mind**: if protection rules (e.g. required reviewers) are later added to the `automation` environment, every label-sync triggered by a push to `main` will gate on manual approval. For a fully automated sync workflow that's worth documenting, but it's a future concern, not a current blocker.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a one-line, purely additive change with no logic modifications.
- The diff is a single line addition that follows GitHub Actions best practices. The placement (job-level) is correct, the environment was pre-created, and repo-level secrets remain accessible to environment-scoped jobs, so there's no functional regression risk. Confidence is maxed out. 🤓
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/label-sync.yml | Adds `environment: automation` at the job level to scope `GH_PAT_WORKFLOW_DISPATCH` secret access to a named environment, satisfying zizmor's `secrets-outside-env` lint rule. Change is syntactically correct and placed at the right level in the YAML hierarchy. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GH as GitHub Actions
    participant Env as automation Environment
    participant SM as Secrets Manager
    participant Job as sync Job

    GH->>Env: Job requests environment context
    Env-->>GH: Environment approved (no protection rules = instant)
    GH->>SM: Fetch secrets for environment + repo scope
    SM-->>Job: GH_PAT_WORKFLOW_DISPATCH injected
    Job->>Job: Step 1 — EndBug/label-sync (uses GITHUB_TOKEN)
    Job->>Job: Step 2 — gh label clone loop (uses GH_PAT_WORKFLOW_DISPATCH)
    Job-->>GH: Workflow complete
```

<sub>Last reviewed commit: 5725a51</sub>

<!-- /greptile_comment -->