### PR TITLE
fix(release-please): use GitHub App token so PRs trigger CI workflows

### DIFF
--- a/.github/workflows/_release-please.yml
+++ b/.github/workflows/_release-please.yml
@@ -2,17 +2,22 @@
 # Automates versioning and changelog via conventional commits.
 #
 # All release configuration is inlined as action inputs.
-# Calling repos only need:
-#   uses: JacobPEvans/.github/.github/workflows/_release-please.yml@main
-#   secrets: inherit
+# Calling repos should pass secrets explicitly:
+#
+#   jobs:
+#     release-please:
+#       uses: JacobPEvans/.github/.github/workflows/_release-please.yml@main
+#       secrets:
+#         GH_ACTION_JACOBPEVANS_APP_ID: ${{ secrets.GH_ACTION_JACOBPEVANS_APP_ID }}
+#         GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
 #
 # Required files in each calling repo:
 #   VERSION                         - plain-text current version (e.g. "1.2.3")
 #   .release-please-manifest.json  - release-please manifest (e.g. {"." : "1.2.3"})
 #
-# Secrets required (passed via `secrets: inherit` from caller):
-#   GH_ACTION_JACOBPEVANS_APP_ID  - GitHub App ID
-#   GH_APP_PRIVATE_KEY            - GitHub App private key
+# Secrets required:
+#   GH_ACTION_JACOBPEVANS_APP_ID  - GitHub App ID (repo-level secret)
+#   GH_APP_PRIVATE_KEY            - GitHub App private key (repo-level secret)
 #
 # The GitHub App token is required so release-please PRs trigger `pull_request`
 # workflows (e.g. CI Gate). PRs created with GITHUB_TOKEN do NOT trigger them.
@@ -36,8 +41,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     steps:
       - uses: actions/checkout@v6
 
@@ -78,8 +82,9 @@ jobs:
         if: steps.release.outputs.prs_created == 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          BASE_BRANCH: ${{ github.ref_name }}
         run: |
-          PR_NUMBER=$(gh pr list --head "release-please--branches--main" --json number --jq '.[0].number // empty')
+          PR_NUMBER=$(gh pr list --head "release-please--branches--${BASE_BRANCH}" --json number --jq '.[0].number // empty')
           if [ -n "$PR_NUMBER" ]; then
             gh pr merge "$PR_NUMBER" --auto --squash
           fi

--- a/.github/workflows/_release-please.yml
+++ b/.github/workflows/_release-please.yml
@@ -2,15 +2,29 @@
 # Automates versioning and changelog via conventional commits.
 #
 # All release configuration is inlined as action inputs.
-# Calling repos only need: uses: JacobPEvans/.github/.github/workflows/_release-please.yml@main
+# Calling repos only need:
+#   uses: JacobPEvans/.github/.github/workflows/_release-please.yml@main
+#   secrets: inherit
 #
 # Required files in each calling repo:
 #   VERSION                         - plain-text current version (e.g. "1.2.3")
 #   .release-please-manifest.json  - release-please manifest (e.g. {"." : "1.2.3"})
+#
+# Secrets required (passed via `secrets: inherit` from caller):
+#   GH_ACTION_JACOBPEVANS_APP_ID  - GitHub App ID
+#   GH_APP_PRIVATE_KEY            - GitHub App private key
+#
+# The GitHub App token is required so release-please PRs trigger `pull_request`
+# workflows (e.g. CI Gate). PRs created with GITHUB_TOKEN do NOT trigger them.
 name: _release-please
 
 on:
   workflow_call:
+    secrets:
+      GH_ACTION_JACOBPEVANS_APP_ID:
+        required: true
+      GH_APP_PRIVATE_KEY:
+        required: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -27,9 +41,17 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.GH_ACTION_JACOBPEVANS_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+
       - uses: googleapis/release-please-action@v4
         id: release
         with:
+          token: ${{ steps.app-token.outputs.token }}
           release-type: simple
           version-file: VERSION
           include-v-in-tag: true
@@ -55,7 +77,7 @@ jobs:
       - name: Enable auto-merge for release PR
         if: steps.release.outputs.prs_created == 'true'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           PR_NUMBER=$(gh pr list --head "release-please--branches--main" --json number --jq '.[0].number // empty')
           if [ -n "$PR_NUMBER" ]; then


### PR DESCRIPTION
## Summary

- Switch `googleapis/release-please-action@v4` from `GITHUB_TOKEN` to a GitHub App token
- Declare required secrets (`GH_ACTION_JACOBPEVANS_APP_ID`, `GH_APP_PRIVATE_KEY`) in `workflow_call.secrets`
- Use app token for the auto-merge step as well

## Root Cause

GitHub does not trigger `pull_request` events for PRs created by `GITHUB_TOKEN` (anti-loop protection). This means `ci-gate.yml` (Merge Gate) never ran on release-please PRs, blocking them indefinitely.

## Fix

PRs created by a GitHub App token **do** trigger `pull_request` events. Callers must add explicit secret forwarding:

```yaml
secrets:
  GH_ACTION_JACOBPEVANS_APP_ID: ${{ secrets.GH_ACTION_JACOBPEVANS_APP_ID }}
  GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
```

## Test plan

- [ ] Merge this PR first
- [ ] Verify nix-darwin PR passes and triggers CI Gate on the next release-please PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a classic GitHub Actions bootstrapping puzzle 🧩: `GITHUB_TOKEN`-created PRs are silently excluded from `pull_request` events (GitHub's anti-loop protection), so the CI Gate workflow (`codeql.yml`, etc.) never ran on release-please PRs, causing them to stall forever. The fix swaps in a GitHub App token — PRs opened by an App *do* fire `pull_request` events — by adding an `actions/create-github-app-token@v2` step and threading the resulting token through both the `googleapis/release-please-action@v4` call and the auto-merge `gh pr merge` step.

**Key changes:**
- Two new `workflow_call` secrets declared (`GH_ACTION_JACOBPEVANS_APP_ID`, `GH_APP_PRIVATE_KEY`) — callers just need `secrets: inherit`
- `Generate GitHub App Token` step added before any GitHub API interaction
- App token replaces `github.token` / `GITHUB_TOKEN` in both the release-please action and the auto-merge step
- Header comment updated to document the new secret requirements and the reason for the app token

**One minor style nit:**  The App ID is stored as a sensitive value when it's actually public information (visible in GitHub URLs and API responses); storing it as a repository `var` instead would follow GitHub's own guidance and keep the secrets store lean.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it correctly resolves the GITHUB_TOKEN CI-trigger limitation with a well-understood GitHub App token pattern, and the change is scoped to a single reusable workflow file.
- The root cause is well-understood and the fix is idiomatic. Token is generated once and consistently applied to both downstream steps. The only non-critical concern is storing the App ID (public info) in the secrets store rather than `vars`, which is purely a best-practice deviation with no security or functional impact. No logic bugs, no missing error handling, no race conditions introduced.
- No files require special attention — the single changed file is clean and well-commented.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/_release-please.yml | Switches release-please from GITHUB_TOKEN to a GitHub App token via `actions/create-github-app-token@v2`; two required secrets declared; token applied to both the release-please action and auto-merge step. One style nit: the App ID (public, non-sensitive) is stored as a `secret` rather than a `var`. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Push as git push → main
    participant RP as _release-please.yml
    participant AppToken as actions/create-github-app-token@v2
    participant RPAPI as googleapis/release-please-action@v4
    participant GH as GitHub API
    participant CI as CI Gate (pull_request workflows)

    Push->>RP: triggers workflow_call
    RP->>AppToken: app-id + private-key
    AppToken-->>RP: app installation token
    RP->>RPAPI: token = app token
    RPAPI->>GH: create/update release PR (as GitHub App)
    GH-->>CI: pull_request event fires ✅
    Note over GH,CI: With GITHUB_TOKEN this event was suppressed ❌
    RP->>GH: gh pr merge --auto --squash (if prs_created)
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/_release-please.yml
Line: 24-25

Comment:
**App ID stored as a sensitive value instead of a variable**

The GitHub App ID (`GH_ACTION_JACOBPEVANS_APP_ID`) is non-sensitive public information — it's visible in your App's settings URL and GitHub API responses. GitHub's own docs recommend using [repository/organization **variables**](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables) (`vars.*`) for non-sensitive configuration and reserving the secrets store for truly sensitive values like the private key.

Storing it in the sensitive values store works functionally, but it:
- Unnecessarily consumes a slot in your secrets quota
- Masks the value in logs, making it harder to inspect/debug
- Deviates from the standard pattern shown in `actions/create-github-app-token`'s own docs, which typically use `vars.APP_ID`

Consider exposing the App ID as a workflow `input` instead, and having callers pass it from `vars.GH_ACTION_JACOBPEVANS_APP_ID`.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: 87f1acf</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->