### PR TITLE
fix(renovate): reorder rules to enable major automerge

### DIFF
--- a/.readme-validator.yaml
+++ b/.readme-validator.yaml
@@ -1,0 +1,10 @@
+# README validation config for .github meta-repository
+# This repo contains org-wide defaults and configurations, not a library.
+# Installation/Usage sections are not applicable.
+required_sections:
+  - Repository Structure
+optional_sections:
+  - Contributing
+  - License
+  - Label System
+  - API

--- a/README.md
+++ b/README.md
@@ -145,7 +145,6 @@ Standardized [pull request templates][pr-templates-docs] that enforce convention
 | ----------------------- | ------------------------------------ | -------------------- |
 | `auto-label-issues.yml` | Apply priority/size from issue forms | Issue creation       |
 | `label-sync.yml`        | Deploy `labels.yml` to all repos     | Push to main, manual |
-| `_auto-merge.yml`       | Reusable: squash auto-merge          | `workflow_call`      |
 | `_file-size.yml`        | Reusable: file size/line checks      | `workflow_call`      |
 | `_markdown-lint.yml`    | Reusable: markdownlint-cli2          | `workflow_call`      |
 | `_nix-build.yml`        | Reusable: Nix build (macOS)          | `workflow_call`      |

--- a/renovate-presets.json
+++ b/renovate-presets.json
@@ -4,6 +4,11 @@
   "platformAutomerge": true,
   "packageRules": [
     {
+      "description": "Never auto-merge major updates - require human review (overridden by trusted package rules below)",
+      "matchUpdateTypes": ["major"],
+      "automerge": false
+    },
+    {
       "description": "Auto-merge JacobPEvans-owned GitHub Actions (immediate)",
       "matchDatasources": ["github-actions"],
       "matchPackageNames": ["JacobPEvans/**"],
@@ -23,7 +28,15 @@
         "DeterminateSystems/**",
         "peter-evans/**",
         "DavidAnson/**",
-        "aquasecurity/**"
+        "aquasecurity/**",
+        "dorny/**",
+        "github/**",
+        "softprops/**",
+        "hashicorp/**",
+        "opentofu/**",
+        "python/**",
+        "microsoft/**",
+        "Azure/**"
       ],
       "automerge": true,
       "automergeType": "pr",
@@ -38,11 +51,6 @@
       "automergeType": "pr",
       "automergeStrategy": "squash",
       "minimumReleaseAge": "3 days"
-    },
-    {
-      "description": "Never auto-merge major updates - require human review",
-      "matchUpdateTypes": ["major"],
-      "automerge": false
     }
   ]
 }


### PR DESCRIPTION
## Summary

- **Reorder `packageRules`**: Move the blanket major-block rule to position 1 so trusted package rules (positions 2–3) override it. Renovate's last-match-wins means the major block was previously silencing auto-merge for trusted orgs on major bumps (e.g., `actions/create-github-app-token` v2→v3).
- **Expand trusted orgs**: Add `dorny`, `github`, `softprops`, `hashicorp`, `opentofu`, `python`, `microsoft`, `Azure` to the trusted GitHub Actions list.
- **Remove stale `_auto-merge.yml` README reference**: The workflow was never created; auto-merge is handled by Renovate's `platformAutomerge` + `packageRules`.
- **Add `.readme-validator.yaml`**: Configure appropriate required sections for this meta-repository (defaults require Installation/Usage which don't apply here).

## Root Cause

```
Rule 1: JacobPEvans/** → automerge: true        (matches)
Rule 2: actions/**     → automerge: true         (matches)
Rule 3: major          → automerge: false        (OVERRIDES — last match wins)
```

After this fix:
```
Rule 1: major          → automerge: false        (default deny)
Rule 2: JacobPEvans/** → automerge: true         (overrides)
Rule 3: trusted orgs   → automerge: true         (overrides)
```

## Test plan

- [ ] After merge, verify `nix-home#65` (`actions/create-github-app-token` v2→v3) gets auto-merge enabled by Renovate
- [ ] Monitor next Renovate major bump for a trusted org — confirm it auto-merges after stabilization period

Generated with Claude Code
