### PR TITLE
feat: add Nix flake input auto-merge rules to org preset

### DIFF
--- a/renovate-presets.json
+++ b/renovate-presets.json
@@ -55,15 +55,16 @@
     {
       "description": "Auto-merge JacobPEvans-owned Nix flake inputs (immediate)",
       "matchManagers": ["nix"],
+      "matchDatasources": ["git-refs"],
       "matchPackageNames": ["https://github.com/JacobPEvans/**"],
       "automerge": true,
       "automergeType": "pr",
-      "automergeStrategy": "squash",
-      "minimumReleaseAge": "0 days"
+      "automergeStrategy": "squash"
     },
     {
-      "description": "Auto-merge trusted Nix flake inputs (3-day stabilization)",
+      "description": "Auto-merge trusted Nix flake inputs (immediate, CI-gated)",
       "matchManagers": ["nix"],
+      "matchDatasources": ["git-refs"],
       "matchPackageNames": [
         "https://github.com/NixOS/**",
         "https://github.com/nix-community/**",
@@ -78,8 +79,7 @@
       ],
       "automerge": true,
       "automergeType": "pr",
-      "automergeStrategy": "squash",
-      "minimumReleaseAge": "3 days"
+      "automergeStrategy": "squash"
     }
   ]
 }

--- a/renovate-presets.json
+++ b/renovate-presets.json
@@ -51,6 +51,35 @@
       "automergeType": "pr",
       "automergeStrategy": "squash",
       "minimumReleaseAge": "3 days"
+    },
+    {
+      "description": "Auto-merge JacobPEvans-owned Nix flake inputs (immediate)",
+      "matchManagers": ["nix"],
+      "matchPackageNames": ["https://github.com/JacobPEvans/**"],
+      "automerge": true,
+      "automergeType": "pr",
+      "automergeStrategy": "squash",
+      "minimumReleaseAge": "0 days"
+    },
+    {
+      "description": "Auto-merge trusted Nix flake inputs (3-day stabilization)",
+      "matchManagers": ["nix"],
+      "matchPackageNames": [
+        "https://github.com/NixOS/**",
+        "https://github.com/nix-community/**",
+        "https://github.com/cachix/**",
+        "https://github.com/anthropics/**",
+        "https://github.com/numtide/**",
+        "https://github.com/hercules-ci/**",
+        "https://github.com/DeterminateSystems/**",
+        "https://github.com/edolstra/**",
+        "https://github.com/oxalica/**",
+        "https://github.com/wakatime/**"
+      ],
+      "automerge": true,
+      "automergeType": "pr",
+      "automergeStrategy": "squash",
+      "minimumReleaseAge": "3 days"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add `packageRules` for Renovate's `nix` manager (`git-refs` datasource)
- JacobPEvans-owned flake inputs: immediate auto-merge via squash
- Trusted Nix ecosystem owners (NixOS, nix-community, cachix, anthropics, etc.): auto-merge after 3-day stabilization
- Untrusted community plugin owners still require manual review

This is the centralized half of migrating flake.lock updates from custom `deps-update-flake.yml` workflows to Renovate's native nix manager. Per-repo opt-in via `"nix": { "enabled": true }` in each repo's `renovate.json`.

## Merge order
1. **This PR first** (preset must exist before repos reference it)
2. Then per-repo PRs in nix-ai, nix-home, nix-darwin

## Test plan
- [ ] After merge, verify Renovate creates individual PRs per flake input in nix-ai
- [ ] Verify trusted owner inputs (e.g. JacobPEvans/ai-assistant-instructions) get auto-merge enabled
- [ ] Verify untrusted owner inputs (e.g. BillChirico/bills-claude-skills) require manual review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds two `packageRules` entries to the org-wide Renovate preset for the `nix` manager (flake input updates via `git-refs` datasource). JacobPEvans-owned flake inputs get immediate auto-merge, while a curated list of trusted Nix ecosystem orgs gets auto-merge after a 3-day stabilization window. The approach fits cleanly into the existing tiered auto-merge pattern already used for GitHub Actions and pre-commit rules.

**Key findings:**

- ✅ Package name format is correct — Renovate docs confirm `packageName` for nix manager is the fully-qualified HTTPS URL (e.g. `https://github.com/NixOS/nixpkgs`), matching the glob patterns used here
- ✅ Rule ordering is correct — the top-level `"matchUpdateTypes": ["major"], "automerge": false` rule doesn't interfere since flake input updates are `digest` type, not `major`
- ✅ The `matchManagers: ["nix"]` constraint correctly scopes these rules to flake inputs only
- ⚠️ **`minimumReleaseAge` may be ineffective for `git-refs`** — the [Renovate `git-refs` datasource docs](https://docs.renovatebot.com/modules/datasource/git-refs/) explicitly state `Release timestamp support: No`. Since `minimumReleaseAge` requires a release timestamp to function, the intended 3-day stabilization window for trusted owners (NixOS, nix-community, cachix, etc.) may be silently ignored, causing immediate auto-merge — or conversely, may permanently block auto-merge. This is worth verifying against a real flake input update before relying on it as a safety control.

<h3>Confidence Score: 3/5</h3>

- Safe to merge, but the 3-day stabilization window for trusted Nix owners may not actually work due to `git-refs` having no release timestamp support — verify empirically before depending on it as a security control.
- The package name format and rule structure are correct. The only real concern is whether `minimumReleaseAge` is honored by the `git-refs` datasource (which explicitly lacks timestamp support). If it's silently ignored, trusted-owner packages auto-merge immediately instead of after 3 days — a divergence from intent but not catastrophic since these are still vetted orgs. Score reflects the unverified behavior of a key safety feature rather than any structural bug.
- renovate-presets.json — specifically lines 65-83 where `minimumReleaseAge: "3 days"` may not be honored by the `git-refs` datasource

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| renovate-presets.json | Adds two new `packageRules` blocks for the `nix` manager. Package name format using full HTTPS URLs is correct per Renovate docs. However, `minimumReleaseAge` for the trusted-owner rule may be silently ineffective since the `git-refs` datasource doesn't support release timestamps — undermining the intended 3-day stabilization window. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Renovate detects nix flake input update\ngit-refs datasource] --> B{matchManagers: nix}
    B -->|No match| Z[Default Renovate behavior]
    B -->|Match| C{matchPackageNames}

    C -->|https://github.com/JacobPEvans/**| D[Rule: JacobPEvans-owned\nautomerge: true\nminimumReleaseAge: 0 days\nstrategy: squash]
    C -->|NixOS / nix-community / cachix\nanthropics / numtide / hercules-ci\nDeterminateSystems / edolstra\noxalica / wakatime| E[Rule: Trusted owners\nautomerge: true\nminimumReleaseAge: 3 days ⚠️\nstrategy: squash]
    C -->|No match - untrusted owner| F[No automerge\nManual review required]

    D --> G[PR opened → auto-merged immediately ✅]
    E --> H{git-refs has release timestamp?}
    H -->|No — datasource limitation ⚠️| I[minimumReleaseAge may be\nsilently ignored or block forever]
    H -->|Yes — if resolved| J[Wait 3 days → auto-merge ✅]
    F --> K[PR stays open for human review]

    style I fill:#ff9999,color:#000
    style H fill:#ffcc00,color:#000
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: renovate-presets.json
Line: 65-83

Comment:
**`minimumReleaseAge` may be ineffective for `git-refs`**

The `git-refs` datasource [explicitly has no release timestamp support](https://docs.renovatebot.com/modules/datasource/git-refs/) (`Release timestamp support: No`). `minimumReleaseAge` works by checking the age of a release against a timestamp provided by the datasource. Since `git-refs` doesn't provide timestamps, this 3-day stabilization window is almost certainly either silently ignored (causing immediate auto-merge against your intent) or causes Renovate to perpetually block auto-merge.

The Renovate docs for the `nix` manager specifically call out:

> For specifying `packageRules` it is important to know how `depName` and `packageName` are defined for nix updates

...but make no mention of `minimumReleaseAge` being supported.

Since these trusted-but-not-owned orgs (NixOS, nix-community, cachix, etc.) are exactly the ones where a 3-day hold provides real value (supply chain protection, catching accidental breaking changes), it's worth verifying empirically whether this setting is honored. If it isn't, you may want to either remove the `minimumReleaseAge` (and accept immediate auto-merge for trusted owners) or switch to `automergeSchedule` as an alternative delay mechanism:

```json
{
  "description": "Auto-merge trusted Nix flake inputs (3-day stabilization)",
  "matchManagers": ["nix"],
  "matchPackageNames": [
    "https://github.com/NixOS/**",
    "https://github.com/nix-community/**",
    "https://github.com/cachix/**",
    "https://github.com/anthropics/**",
    "https://github.com/numtide/**",
    "https://github.com/hercules-ci/**",
    "https://github.com/DeterminateSystems/**",
    "https://github.com/edolstra/**",
    "https://github.com/oxalica/**",
    "https://github.com/wakatime/**"
  ],
  "automerge": true,
  "automergeType": "pr",
  "automergeStrategy": "squash",
  "minimumReleaseAge": "3 days",
  "automergeSchedule": ["after 3am on monday"]
}
```

Note the same concern applies to `minimumReleaseAge: "0 days"` in the JacobPEvans-owned rule (line 62), though that one's intent (immediate merge) is still achieved either way.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: 8808426</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->