### PR TITLE
feat(ci): add org-default markdownlint config with workflow fallback

### DIFF
--- a/.github/workflows/_markdown-lint.yml
+++ b/.github/workflows/_markdown-lint.yml
@@ -1,5 +1,5 @@
 # Reusable: Markdown Lint
-# Generic markdown linting — uses the calling repo's own markdownlint config.
+# Uses the calling repo's own markdownlint config, falling back to org defaults.
 name: _markdown-lint
 
 on:
@@ -19,6 +19,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
+      - name: Apply org-default markdownlint config
+        if: hashFiles('.markdownlint-cli2.yaml', '.markdownlint-cli2.cjs', '.markdownlint-cli2.mjs', '.markdownlint.yaml', '.markdownlint.json', '.markdownlint.jsonc', '.markdownlint.yml') == ''
+        run: |
+          curl -sSfL "https://raw.githubusercontent.com/${{ github.repository_owner }}/.github/main/configs/.markdownlint-cli2.yaml" \
+            -o .markdownlint-cli2.yaml
 
       - name: Run markdownlint
         uses: DavidAnson/markdownlint-cli2-action@v22

--- a/.github/workflows/_markdown-lint.yml
+++ b/.github/workflows/_markdown-lint.yml
@@ -21,9 +21,10 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Apply org-default markdownlint config
-        if: hashFiles('.markdownlint-cli2.yaml', '.markdownlint-cli2.cjs', '.markdownlint-cli2.mjs', '.markdownlint.yaml', '.markdownlint.json', '.markdownlint.jsonc', '.markdownlint.yml') == ''
+        if: hashFiles('.markdownlint-cli2.jsonc', '.markdownlint-cli2.yaml', '.markdownlint-cli2.cjs', '.markdownlint-cli2.mjs', '.markdownlint.jsonc', '.markdownlint.json', '.markdownlint.yaml', '.markdownlint.yml', '.markdownlint.cjs', '.markdownlint.mjs') == ''
         run: |
-          curl -sSfL "https://raw.githubusercontent.com/${{ github.repository_owner }}/.github/main/configs/.markdownlint-cli2.yaml" \
+          curl -sSfL --retry 3 --retry-connrefused \
+            "https://raw.githubusercontent.com/${{ github.repository_owner }}/.github/main/configs/.markdownlint-cli2.yaml" \
             -o .markdownlint-cli2.yaml
 
       - name: Run markdownlint

--- a/configs/.markdownlint-cli2.yaml
+++ b/configs/.markdownlint-cli2.yaml
@@ -2,6 +2,13 @@
 # Repos inherit this via the _markdown-lint.yml reusable workflow.
 # To override: add a .markdownlint-cli2.yaml to your repo root.
 config:
+  MD013:
+    line_length: 160
+    heading_line_length: 80
+    code_block_line_length: 80
+    tables: true
+    strict: true
+
   # Allow duplicate headings in different sections (standard for changelogs)
   MD024:
     siblings_only: true

--- a/configs/.markdownlint-cli2.yaml
+++ b/configs/.markdownlint-cli2.yaml
@@ -1,0 +1,15 @@
+# Organization-wide markdownlint defaults
+# Repos inherit this via the _markdown-lint.yml reusable workflow.
+# To override: add a .markdownlint-cli2.yaml to your repo root.
+config:
+  # Allow duplicate headings in different sections (standard for changelogs)
+  MD024:
+    siblings_only: true
+
+# Per-file overrides
+overrides:
+  - files:
+      - "CHANGELOG.md"
+    config:
+      # release-please generates long lines with PR links
+      MD013: false


### PR DESCRIPTION
## Summary
- Add org-wide markdownlint defaults at `configs/.markdownlint-cli2.yaml`
- Update `_markdown-lint.yml` to auto-download org defaults when repos lack local config
- Repos can still provide their own `.markdownlint-cli2.yaml` for overrides
- Default handles release-please CHANGELOG patterns (MD024 siblings_only, MD013 for CHANGELOG.md)

## Test plan
- [ ] Verify CI passes on this PR
- [ ] Verify nix-ai #166 and nix-home #72 pass after this merges

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces an org-wide markdownlint config fallback mechanism. The reusable `_markdown-lint.yml` workflow now checks whether the calling repo has any local markdownlint config; if not, it downloads the org default from `configs/.markdownlint-cli2.yaml`. The default config is minimal and pragmatic — it relaxes MD024 to allow sibling duplicate headings (standard for changelogs) and disables MD013 line-length enforcement specifically for `CHANGELOG.md` files generated by release-please.

- The `hashFiles` guard in the workflow is **missing `.markdownlint-cli2.jsonc`** — the primary config format for markdownlint-cli2 — along with `.markdownlint.cjs` and `.markdownlint.mjs`. A repo using any of these would have its config silently overwritten by the org default.
- The `curl` fallback approach using `${{ github.repository_owner }}` is a nice touch for fork compatibility.
- The new `configs/.markdownlint-cli2.yaml` is clean, well-commented, and follows the markdownlint-cli2 schema correctly.

<h3>Confidence Score: 3/5</h3>

- Safe to merge after addressing the incomplete hashFiles guard — low blast radius but worth fixing to prevent subtle config override bugs
- The core concept is solid and the config file is correct. However, the missing `.markdownlint-cli2.jsonc` (and two other formats) in the hashFiles check is a real bug that could silently overwrite a repo's local config. This isn't a showstopper for the current org repos (which use `.markdownlint.json`), but it's a latent issue for any repo that adopts the primary markdownlint-cli2 config format.
- `.github/workflows/_markdown-lint.yml` — the `hashFiles` condition needs the complete set of markdownlint config filenames

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/_markdown-lint.yml | Adds org-default config fallback step with `hashFiles` guard, but the guard is missing `.markdownlint-cli2.jsonc` (the primary config format) plus `.markdownlint.cjs` and `.markdownlint.mjs`, which could cause silent config overwrites in repos using those formats. |
| configs/.markdownlint-cli2.yaml | New org-wide markdownlint defaults config. Clean YAML with sensible rules: MD024 `siblings_only` for changelogs and MD013 disabled for `CHANGELOG.md` to accommodate release-please output. No issues found. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Calling repo triggers _markdown-lint.yml] --> B[Checkout repo]
    B --> C{hashFiles checks:\nany local markdownlint config?}
    C -->|Config found| E[Run markdownlint-cli2\nwith local config]
    C -->|No config found| D["curl org default from\nconfigs/.markdownlint-cli2.yaml"]
    D --> E
    E --> F{Lint result}
    F -->|Pass| G[✅ Job succeeds]
    F -->|Fail| H[❌ Job fails with violations]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/_markdown-lint.yml
Line: 24

Comment:
**Missing `.markdownlint-cli2.jsonc` in hashFiles check**

The `hashFiles` guard is missing `.markdownlint-cli2.jsonc`, which is the **primary** config format for markdownlint-cli2 (it's the first one the tool searches for). If a repo uses `.markdownlint-cli2.jsonc` for its config, this condition will evaluate to `''` and the org default will overwrite it.

Also missing are `.markdownlint.cjs` and `.markdownlint.mjs` — both valid markdownlint config formats.

The full set of supported config filenames per [markdownlint-cli2 docs](https://github.com/DavidAnson/markdownlint-cli2#markdownlint-cli2jsonc) is:
- `.markdownlint-cli2.jsonc`, `.markdownlint-cli2.yaml`, `.markdownlint-cli2.cjs`, `.markdownlint-cli2.mjs`
- `.markdownlint.jsonc`, `.markdownlint.json`, `.markdownlint.yaml`, `.markdownlint.yml`, `.markdownlint.cjs`, `.markdownlint.mjs`

```suggestion
        if: hashFiles('.markdownlint-cli2.jsonc', '.markdownlint-cli2.yaml', '.markdownlint-cli2.cjs', '.markdownlint-cli2.mjs', '.markdownlint.jsonc', '.markdownlint.json', '.markdownlint.yaml', '.markdownlint.yml', '.markdownlint.cjs', '.markdownlint.mjs') == ''
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: b921213</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->