### PR TITLE
chore: remove orphaned rate-limit-config.json

### DIFF
--- a/.github/rate-limit-config.json
+++ b/.github/rate-limit-config.json
@@ -1,7 +1,0 @@
-{
-  "trusted_user_ids": [20714140],
-  "limits": {
-    "trusted": {"issues_24h": 10, "prs_24h": 20},
-    "default": {"issues_24h": 5, "prs_24h": 5}
-  }
-}


### PR DESCRIPTION
## Summary
- Remove `.github/rate-limit-config.json` — no longer consumed by any workflow or hook
- Two-tier rate limiting was removed in [claude-code-plugins PR #125](https://github.com/JacobPEvans/claude-code-plugins/pull/125); the enforce-issue-limits hook now uses hardcoded limits

## Test plan
- [x] Verified no references to `rate-limit-config` exist in claude-code-plugins or this repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)