### PR TITLE
fix(ci): remove flake-checker-action (Node.js 20 deprecation)

### DIFF
--- a/.github/workflows/_nix-validate.yml
+++ b/.github/workflows/_nix-validate.yml
@@ -43,11 +43,6 @@ jobs:
           restore-keys: |
             nix-linux-${{ runner.os }}-
 
-      - name: Lint flake.lock
-        uses: DeterminateSystems/flake-checker-action@main
-        with:
-          nixpkgs-keys: nixpkgs
-
       - name: Check flake
         run: nix flake check --print-build-logs
 


### PR DESCRIPTION
## Summary

- Removes `DeterminateSystems/flake-checker-action@main` from `_nix-validate.yml` reusable workflow
- `determinate-nix-action@v3` (already in use for Nix installation) bundles flake checking, making the separate step redundant
- Eliminates the Node.js 20 deprecation warning ahead of GitHub's June 2, 2026 deadline

## Test plan

- [ ] CI runs without Node.js 20 deprecation warnings
- [ ] `nix flake check` still passes in downstream repos that consume this reusable workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)