### PR TITLE
chore(renovate): add raycast as trusted org

### DIFF
--- a/renovate-presets.json
+++ b/renovate-presets.json
@@ -36,7 +36,8 @@
         "opentofu/**",
         "python/**",
         "microsoft/**",
-        "Azure/**"
+        "Azure/**",
+        "raycast/**"
       ],
       "automerge": true,
       "automergeType": "pr",


### PR DESCRIPTION
## Summary

- Add `raycast/**` to trusted packages list in `renovate-presets.json`
- Enables automerge for minor/patch raycast dependency updates (3-day stabilization)

## Test plan

- [x] JSON is valid
- [ ] Renovate picks up the preset change

🤖 Generated with [Claude Code](https://claude.com/claude-code)