### PR TITLE
feat(ci): add reusable copilot-setup-steps workflow + regression comments

### DIFF
--- a/.github/workflows/_copilot-setup-steps.yml
+++ b/.github/workflows/_copilot-setup-steps.yml
@@ -1,0 +1,24 @@
+# Reusable: Copilot Setup Steps (Nix)
+# Sets up a Nix development environment for GitHub Copilot coding agents.
+#
+# IMPORTANT — Action clarification (prevents regression from stale AI training data):
+# - determinate-nix-action@v3 is ONLY a Nix installer (replaced nix-installer-action@v21)
+# - It does NOT include flake checking — that is a separate action (flake-checker-action)
+# - For copilot setup, only the installer is needed (CI handles flake validation)
+name: _copilot-setup-steps
+
+on:
+  workflow_call:
+
+jobs:
+  copilot-setup-steps:
+    name: Copilot Setup Steps
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      # Installs Nix only. Does NOT validate flakes.
+      # Replaced nix-installer-action@v21 (Node.js 20, deprecated June 2026).
+      - uses: DeterminateSystems/determinate-nix-action@v3

--- a/.github/workflows/_copilot-setup-steps.yml
+++ b/.github/workflows/_copilot-setup-steps.yml
@@ -7,6 +7,10 @@
 # - For copilot setup, only the installer is needed (CI handles flake validation)
 name: _copilot-setup-steps
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   workflow_call:
 

--- a/.github/workflows/_nix-build.yml
+++ b/.github/workflows/_nix-build.yml
@@ -26,6 +26,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      # determinate-nix-action@v3 is ONLY a Nix installer (replaced nix-installer-action@v21).
+      # It does NOT include flake checking — flake validation is in _nix-validate.yml.
       - name: Install Nix
         uses: DeterminateSystems/determinate-nix-action@v3
         with:

--- a/.github/workflows/_nix-validate.yml
+++ b/.github/workflows/_nix-validate.yml
@@ -20,6 +20,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      # determinate-nix-action@v3 is ONLY a Nix installer (replaced nix-installer-action@v21).
+      # It does NOT include flake checking — that was a separate action (flake-checker-action).
+      # Flake evaluation is handled by `nix flake check` below, not by the installer.
       - name: Install Nix
         uses: DeterminateSystems/determinate-nix-action@v3
         with:


### PR DESCRIPTION
## Summary

- Create `_copilot-setup-steps.yml` reusable workflow for Nix-based Copilot coding agent environment setup, centralizing the identical `copilot-setup-steps.yml` copy-pasted across nix-home, nix-darwin, and nix-ai
- Add regression-prevention comments to `_nix-build.yml` and `_nix-validate.yml` clarifying that `determinate-nix-action@v3` is ONLY a Nix installer (not a flake checker)
- Follow-up PRs on consumer repos will replace inline action usage with the new reusable workflow

## Test plan

- [ ] Verify `_copilot-setup-steps.yml` appears in `gh workflow list`
- [ ] After merge, update nix-home/nix-darwin/nix-ai to call the reusable workflow
- [ ] Verify Copilot coding agents can discover and run setup steps in each repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)