### PR TITLE
fix(ci): auto-approve release-please
  PRs to unblock auto-merge

### DIFF
--- a/.github/workflows/_release-please.yml
+++ b/.github/workflows/_release-please.yml
@@ -14,6 +14,10 @@
 #         GH_ACTION_JACOBPEVANS_APP_ID: ${{ secrets.GH_ACTION_JACOBPEVANS_APP_ID }}
 #         GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
 #
+# Org/repo prerequisites:
+#   "Allow GitHub Actions to create and approve pull requests" must be enabled
+#   Calling repos must grant `pull-requests: write` in the caller job permissions
+#
 # Required files in each calling repo:
 #   VERSION                         - plain-text current version (e.g. "1.2.3")
 #   .release-please-manifest.json  - release-please manifest (e.g. {"." : "1.2.3"})
@@ -82,24 +86,26 @@ jobs:
             ]
           manifest-file: .release-please-manifest.json
 
-      - name: Enable auto-merge for release PR
+      - name: Find release PR number
+        id: find-pr
         if: steps.release.outputs.prs_created == 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           BASE_BRANCH: ${{ github.ref_name }}
         run: |
           PR_NUMBER=$(gh pr list --head "release-please--branches--${BASE_BRANCH}" --json number --jq '.[0].number // empty')
-          if [ -n "$PR_NUMBER" ]; then
-            gh pr merge "$PR_NUMBER" --auto --squash
-          fi
+          echo "number=$PR_NUMBER" >> $GITHUB_OUTPUT
+
+      - name: Enable auto-merge for release PR
+        if: steps.find-pr.outputs.number != ''
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ steps.find-pr.outputs.number }}
+        run: gh pr merge "$PR_NUMBER" --auto --squash
 
       - name: Approve release PR
-        if: steps.release.outputs.prs_created == 'true'
+        if: steps.find-pr.outputs.number != ''
         env:
           GH_TOKEN: ${{ github.token }}
-          BASE_BRANCH: ${{ github.ref_name }}
-        run: |
-          PR_NUMBER=$(gh pr list --head "release-please--branches--${BASE_BRANCH}" --json number --jq '.[0].number // empty')
-          if [ -n "$PR_NUMBER" ]; then
-            gh pr review "$PR_NUMBER" --approve
-          fi
+          PR_NUMBER: ${{ steps.find-pr.outputs.number }}
+        run: gh pr review "$PR_NUMBER" --approve

--- a/.github/workflows/_release-please.yml
+++ b/.github/workflows/_release-please.yml
@@ -2,10 +2,13 @@
 # Automates versioning and changelog via conventional commits.
 #
 # All release configuration is inlined as action inputs.
-# Calling repos should pass secrets explicitly:
+# Calling repos should pass secrets and permissions explicitly:
 #
 #   jobs:
 #     release-please:
+#       permissions:
+#         contents: read
+#         pull-requests: write
 #       uses: JacobPEvans/.github/.github/workflows/_release-please.yml@main
 #       secrets:
 #         GH_ACTION_JACOBPEVANS_APP_ID: ${{ secrets.GH_ACTION_JACOBPEVANS_APP_ID }}
@@ -42,6 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v6
 
@@ -87,4 +91,15 @@ jobs:
           PR_NUMBER=$(gh pr list --head "release-please--branches--${BASE_BRANCH}" --json number --jq '.[0].number // empty')
           if [ -n "$PR_NUMBER" ]; then
             gh pr merge "$PR_NUMBER" --auto --squash
+          fi
+
+      - name: Approve release PR
+        if: steps.release.outputs.prs_created == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BASE_BRANCH: ${{ github.ref_name }}
+        run: |
+          PR_NUMBER=$(gh pr list --head "release-please--branches--${BASE_BRANCH}" --json number --jq '.[0].number // empty')
+          if [ -n "$PR_NUMBER" ]; then
+            gh pr review "$PR_NUMBER" --approve
           fi


### PR DESCRIPTION
# PR #99 Update

## Summary

Release-please PRs created by the GitHub App have auto-merge enabled but never merge because
the pull_request ruleset leaves `reviewDecision` empty. This fix adds a `gh pr review --approve`
step using `GITHUB_TOKEN` (github-actions[bot]) which is a different identity from the PR author
(the GitHub App), satisfying GitHub's self-approval restriction and unblocking auto-merge.

Additionally, the fix documents the org/repo setting required for GITHUB_TOKEN approval and
deduplicates the PR number lookup across auto-merge and approval steps.

## Changes

- `.github/workflows/_release-please.yml` — Add header comment documenting prerequisites,
  extract PR number resolution to dedicated `find-pr` step with output, add approval step
  using GITHUB_TOKEN

## Test Plan

- [x] PR created with correct metadata for approval workflow
- [x] Both commits include standard footer notation
- [x] File changes align with described updates to _release-please.yml workflow
