### PR TITLE
fix(renovate): allow postUpgradeTasks to run nix flake check

### DIFF
--- a/renovate-presets.json
+++ b/renovate-presets.json
@@ -2,6 +2,9 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "description": "JacobPEvans org-wide Renovate preset",
   "platformAutomerge": true,
+  "allowedPostUpgradeCommands": [
+    "^nix flake check --no-build$"
+  ],
   "packageRules": [
     {
       "description": "Never auto-merge major updates - require human review (overridden by trusted package rules below)",


### PR DESCRIPTION
## Summary

- Adds `allowedPostUpgradeCommands` to the org-wide Renovate preset, whitelisting `nix flake check --no-build`
- Fixes `renovate/artifacts` check failures on repos that define `postUpgradeTasks` (e.g., nix-darwin)
- Pre-existing issue since nix-darwin commit `92bbb71` — `postUpgradeTasks` was configured but never ran because the admin-level `allowedPostUpgradeCommands` wasn't set

## Context

Discovered while investigating nix-darwin PR #852 (GitHub Actions major version bumps). The `renovate/artifacts` failure was unrelated to that PR — it affects all Renovate PRs that touch `flake.lock` in repos with `postUpgradeTasks`.

## Test plan

- [ ] Verify next Renovate PR on nix-darwin that touches `flake.lock` no longer shows `renovate/artifacts` failure
- [ ] Confirm `nix flake check --no-build` runs successfully as a post-upgrade task

🤖 Generated with [Claude Code](https://claude.com/claude-code)