### PR TITLE
fix(release-please): grant contents: write for release creation

### DIFF
--- a/.github/workflows/_release-please.yml
+++ b/.github/workflows/_release-please.yml
@@ -7,7 +7,7 @@
 #   jobs:
 #     release-please:
 #       permissions:
-#         contents: read
+#         contents: write
 #         pull-requests: write
 #       uses: JacobPEvans/.github/.github/workflows/_release-please.yml@main
 #       secrets:
@@ -16,7 +16,7 @@
 #
 # Org/repo prerequisites:
 #   "Allow GitHub Actions to create and approve pull requests" must be enabled
-#   Calling repos must grant `pull-requests: write` in the caller job permissions
+#   Calling repos must grant `contents: write` and `pull-requests: write` in the caller job permissions
 #
 # Required files in each calling repo:
 #   VERSION                         - plain-text current version (e.g. "1.2.3")
@@ -48,7 +48,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

- Changes `contents: read` to `contents: write` in the reusable `_release-please.yml` workflow
- Updates the example comment block for callers to match
- The `release-please-action@v4` needs `contents: write` to create GitHub releases via the REST API
- This was causing `Resource not accessible by integration` errors across all caller repos since March 13

## Context

The release-please workflow has been failing with `startup_failure` → `Resource not accessible by integration` since PR #87 updated the workflow to use GitHub App tokens. The `pull-requests: write` permission was missing from callers (fixed separately), but the `contents: write` permission was also needed for the release creation step.

Effective `GITHUB_TOKEN` permissions are the **intersection** of caller and called workflow, so both must grant `contents: write`.

## Test plan

- [ ] Merge this PR first
- [ ] Then merge the matching caller PR in `claude-code-plugins`
- [ ] Verify release-please run succeeds (no `Resource not accessible by integration`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)