### PR TITLE
fix(ci): switch release-please to default semver and block automated major bumps

### DIFF
--- a/.commitlintrc.yaml
+++ b/.commitlintrc.yaml
@@ -6,6 +6,16 @@
 # Reference: https://commitlint.js.org/
 # =============================================================================
 
+parserPreset:
+  parserOpts:
+    # Intentionally excludes `!` before `:` to block breaking change markers.
+    # Major version bumps are human-initiated only via .release-please-manifest.json.
+    headerPattern: "^(\\w+)(?:\\(([\\w\\$\\.\\-\\* ]*)\\))?: (.*)$"
+    headerCorrespondence:
+      - type
+      - scope
+      - subject
+
 extends:
   - "@commitlint/config-conventional"
 

--- a/.github/workflows/_release-please.yml
+++ b/.github/workflows/_release-please.yml
@@ -105,6 +105,12 @@ jobs:
           # Get proposed version from the release PR title
           PR_TITLE=$(gh pr view "$PR_NUMBER" --json title --jq '.title')
           PROPOSED_VERSION=$(echo "$PR_TITLE" | grep -oP '\d+\.\d+\.\d+' | head -1)
+
+          if [ -z "$PROPOSED_VERSION" ]; then
+            echo "::warning::Could not extract version from release PR title: $PR_TITLE"
+            exit 0
+          fi
+
           PROPOSED_MAJOR=$(echo "$PROPOSED_VERSION" | cut -d. -f1)
 
           # Get current version from manifest

--- a/.github/workflows/_release-please.yml
+++ b/.github/workflows/_release-please.yml
@@ -67,11 +67,11 @@ jobs:
           release-type: simple
           version-file: VERSION
           include-v-in-tag: true
-          versioning-strategy: always-bump-minor
-          # Note: `breaking:` commit type is for changelog display only — it shows commits in the
-          # "Breaking Changes" section. It does NOT trigger a semver major bump. Major bumps require
-          # a `BREAKING CHANGE:` footer or `!` suffix (e.g. `feat!:`). With always-bump-minor the
-          # minimum bump is minor regardless.
+          # Version bumps follow standard semver via conventional commits:
+          #   fix:  → patch    feat:  → minor
+          # Automated major bumps are blocked (see guard step below).
+          # Major bumps require manually editing .release-please-manifest.json.
+          # Note: `breaking:` commit type is for changelog display only.
           changelog-types: |
             [
               {"type": "feat", "section": "Features"},
@@ -94,7 +94,28 @@ jobs:
           BASE_BRANCH: ${{ github.ref_name }}
         run: |
           PR_NUMBER=$(gh pr list --head "release-please--branches--${BASE_BRANCH}" --json number --jq '.[0].number // empty')
-          echo "number=$PR_NUMBER" >> $GITHUB_OUTPUT
+          echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+
+      - name: Guard against automated major bumps
+        if: steps.find-pr.outputs.number != ''
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ steps.find-pr.outputs.number }}
+        run: |
+          # Get proposed version from the release PR title
+          PR_TITLE=$(gh pr view "$PR_NUMBER" --json title --jq '.title')
+          PROPOSED_VERSION=$(echo "$PR_TITLE" | grep -oP '\d+\.\d+\.\d+' | head -1)
+          PROPOSED_MAJOR=$(echo "$PROPOSED_VERSION" | cut -d. -f1)
+
+          # Get current version from manifest
+          CURRENT_VERSION=$(jq -r '."."' .release-please-manifest.json)
+          CURRENT_MAJOR=$(echo "$CURRENT_VERSION" | cut -d. -f1)
+
+          if [ "$PROPOSED_MAJOR" != "$CURRENT_MAJOR" ]; then
+            echo "::error::Automated major bump blocked ($CURRENT_VERSION -> $PROPOSED_VERSION). Major bumps require manually editing .release-please-manifest.json."
+            gh pr close "$PR_NUMBER" --comment "Automated major version bump blocked ($CURRENT_VERSION -> $PROPOSED_VERSION). Major bumps are human-initiated only. To perform a major bump, manually edit .release-please-manifest.json and push to main."
+            exit 1
+          fi
 
       - name: Enable auto-merge for release PR
         if: steps.find-pr.outputs.number != ''

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -94,15 +94,15 @@ All PRs must use **conventional commit format** in the title:
 
 **Types** (must match `type:*` labels):
 
-- `feat` - New features (type:feature)
-- `fix` - Bug fixes (type:bug)
+- `feat` - New capabilities, integrations, or significant behavioral changes (type:feature)
+- `fix` - Bug fixes, corrections, config tweaks, small improvements (type:bug)
 - `docs` - Documentation (type:docs)
 - `chore` - Maintenance (type:chore)
 - `ci` - CI/CD changes (type:ci)
 - `test` - Test updates (type:test)
 - `refactor` - Code refactoring (type:refactor)
 - `perf` - Performance (type:perf)
-- `feat!` or `breaking(scope):` - Breaking changes (type:breaking)
+- `breaking` - Breaking changes for changelog display (type:breaking)
 
 **Examples**:
 
@@ -110,7 +110,7 @@ All PRs must use **conventional commit format** in the title:
 - `fix(ui): resolve button alignment issue`
 - `docs(readme): update installation instructions`
 - `chore(deps): update dependencies`
-- `feat!: remove deprecated v1 API endpoints`
+- `breaking(api): remove deprecated v1 API endpoints`
 
 See [Conventional Commits](https://www.conventionalcommits.org/) for full specification.
 


### PR DESCRIPTION
## Summary

- Remove `always-bump-minor` versioning strategy from the reusable `_release-please.yml` workflow so `fix:` commits produce **patch** bumps instead of always bumping minor
- Add a guard step that detects and closes release PRs proposing major version bumps (defense against `feat!:` or `BREAKING CHANGE:` footer slipping through)
- Guard against silent false-negative when the release PR title contains no semver string (early-exit with warning rather than comparing empty strings)
- Block the `!` suffix in commitlint via a custom `parserPreset` that strips `!` from the header pattern
- Expand `feat`/`fix` descriptions in CONTRIBUTING.md to guide proper commit type selection
- Fix pre-existing shellcheck SC2086 warning (unquoted `$GITHUB_OUTPUT`)

## Motivation

With `always-bump-minor`, every commit — feat, fix, chore — bumps the minor version. Across 5-20 PRs/day/repo, versions inflate to v1.150.0+ within months while patch versions are never used. Switching to `default` enables proper semver: `fix:` → patch, `feat:` → minor.

## Changes

- `.commitlintrc.yaml`: Add `parserPreset.parserOpts.headerPattern` that excludes `!` before `:`, blocking breaking-change markers at commit time
- `.github/workflows/_release-please.yml`: Remove `versioning-strategy: always-bump-minor`; add guard step that reads proposed version from release PR title and current version from manifest, closes + errors if major differs; add empty-version guard to prevent silent pass-through; fix SC2086 (`$GITHUB_OUTPUT` quoting)
- `docs/CONTRIBUTING.md`: Clarify `feat`/`fix` scope descriptions; replace `feat!` example with `breaking(scope):` pattern

## Test plan

- [ ] Push a `fix:` commit to a consuming repo → verify release-please PR proposes a **patch** bump
- [ ] Push a `feat:` commit → verify it proposes a **minor** bump
- [ ] Verify the major bump guard by checking a release PR title with a major version change would be closed
- [ ] Confirm `terraform-aws-static-website` (inline config) is unaffected
- [ ] Verify commitlint rejects `feat!: something` but accepts `feat: something`

Companion PR: JacobPEvans/ai-assistant-instructions (docs alignment)
