### PR TITLE
fix(release-please): diagnose app token release permissions

### DIFF
--- a/.github/workflows/_release-please.yml
+++ b/.github/workflows/_release-please.yml
@@ -59,6 +59,8 @@ jobs:
         with:
           app-id: ${{ secrets.GH_ACTION_JACOBPEVANS_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
 
       - uses: googleapis/release-please-action@v4
         id: release

--- a/.github/workflows/_release-please.yml
+++ b/.github/workflows/_release-please.yml
@@ -62,6 +62,25 @@ jobs:
           permission-contents: write
           permission-pull-requests: write
 
+      - name: Debug - test app token permissions
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          echo "Testing app token permissions..."
+          gh api /repos/${{ github.repository }} --jq '.permissions' || true
+          echo "Testing release creation capability..."
+          gh api /repos/${{ github.repository }}/releases --method POST \
+            -f tag_name="test-permissions-probe" \
+            -f name="test" \
+            -f body="probe" \
+            -F draft=true 2>&1 | head -20 || true
+          echo "Cleaning up test release..."
+          RELEASE_ID=$(gh api /repos/${{ github.repository }}/releases/tags/test-permissions-probe --jq '.id' 2>/dev/null || true)
+          if [ -n "$RELEASE_ID" ]; then
+            gh api /repos/${{ github.repository }}/releases/$RELEASE_ID --method DELETE || true
+            git push origin :refs/tags/test-permissions-probe || true
+          fi
+
       - uses: googleapis/release-please-action@v4
         id: release
         with:


### PR DESCRIPTION
## Summary

- Adds explicit `permission-contents: write` and `permission-pull-requests: write` to `create-github-app-token@v3`
- Adds a temporary diagnostic step that tests release creation with the App token directly (creates a draft, then deletes it)
- This isolates whether the issue is the token or the `release-please-action`

## Context

The release-please workflow has been failing with `Resource not accessible by integration` on the create release API. Despite:
- GitHub App having `Contents: Read & Write` configured
- No pending installation permission updates
- Explicit `permission-contents: write` on the token
- `GITHUB_TOKEN` also having `contents: write`

The diagnostic step will show the actual API response when using the App token directly.

**This is a temporary diagnostic commit — the debug step should be removed once the issue is identified.**

## Test plan

- [ ] Merge and push a commit to any repo using this workflow
- [ ] Check the "Debug - test app token permissions" step output
- [ ] If the direct API call succeeds, the issue is in release-please-action
- [ ] If it fails, the issue is genuinely with the App token

🤖 Generated with [Claude Code](https://claude.com/claude-code)