### PR TITLE
fix(release-please): add issues:write and test non-draft releases

### DIFF
--- a/.github/workflows/_release-please.yml
+++ b/.github/workflows/_release-please.yml
@@ -61,25 +61,25 @@ jobs:
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write
+          permission-issues: write
 
-      - name: Debug - test app token permissions
+      - name: Debug - test app token permissions (non-draft)
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          echo "Testing app token permissions..."
-          gh api /repos/${{ github.repository }} --jq '.permissions' || true
-          echo "Testing release creation capability..."
-          gh api /repos/${{ github.repository }}/releases --method POST \
+          echo "=== Testing NON-DRAFT release creation ==="
+          RESULT=$(gh api /repos/${{ github.repository }}/releases --method POST \
             -f tag_name="test-permissions-probe" \
-            -f name="test" \
-            -f body="probe" \
-            -F draft=true 2>&1 | head -20 || true
-          echo "Cleaning up test release..."
-          RELEASE_ID=$(gh api /repos/${{ github.repository }}/releases/tags/test-permissions-probe --jq '.id' 2>/dev/null || true)
-          if [ -n "$RELEASE_ID" ]; then
-            gh api /repos/${{ github.repository }}/releases/"$RELEASE_ID" --method DELETE || true
-            git push origin :refs/tags/test-permissions-probe || true
-          fi
+            -f target_commitish="${{ github.sha }}" \
+            -f name="test-permissions-probe" \
+            -f body="Automated permissions probe — will be deleted" \
+            -F draft=false 2>&1) && echo "SUCCESS: $RESULT" || echo "FAILED: $RESULT"
+          # Cleanup
+          RELEASE_ID=$(gh api /repos/${{ github.repository }}/releases/tags/test-permissions-probe \
+            --jq '.id' 2>/dev/null || true)
+          [ -n "$RELEASE_ID" ] && gh api "/repos/${{ github.repository }}/releases/$RELEASE_ID" \
+            --method DELETE 2>/dev/null || true
+          git push origin :refs/tags/test-permissions-probe 2>/dev/null || true
 
       - uses: googleapis/release-please-action@v4
         id: release


### PR DESCRIPTION
## Summary

- Add `permission-issues: write` to the GitHub App token — release-please needs this to swap `autorelease: pending`/`autorelease: tagged` labels and post comments on PRs (PRs are a subset of Issues in GitHub's API)
- Replace the draft-only diagnostic with a **non-draft** release creation test to determine if App tokens behave differently for published vs draft releases

## Context

The release-please pipeline has been failing since March 13 on every push to `claude-code-plugins` main:
```
release-please failed: Resource not accessible by integration - .../releases#create-a-release
```

### Root causes identified
1. **PR #118 stuck with `autorelease: pending`** — already fixed by swapping labels to `autorelease: tagged`
2. **Missing `permission-issues: write`** on the App token — release-please calls `octokit.issues.createComment()`, `octokit.issues.removeLabel()`, and `octokit.issues.addLabels()` after release creation

### Pre-requisite
The GitHub App installation must have `Issues: Read & Write` enabled. If not, the token creation step will fail with a clear error.

## Test plan

- [ ] Merge this PR to main
- [ ] Re-run the latest failed release-please workflow in `claude-code-plugins`
- [ ] Verify the non-draft diagnostic step succeeds (confirms App token can create published releases)
- [ ] Verify release-please no longer fails with "Resource not accessible by integration"
- [ ] Once confirmed working, remove the diagnostic step in a follow-up PR