### PR TITLE
chore(release-please): remove diagnostic step

### DIFF
--- a/.github/workflows/_release-please.yml
+++ b/.github/workflows/_release-please.yml
@@ -63,24 +63,6 @@ jobs:
           permission-pull-requests: write
           permission-issues: write
 
-      - name: Debug - test app token permissions (non-draft)
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          echo "=== Testing NON-DRAFT release creation ==="
-          RESULT=$(gh api /repos/${{ github.repository }}/releases --method POST \
-            -f tag_name="test-permissions-probe" \
-            -f target_commitish="${{ github.sha }}" \
-            -f name="test-permissions-probe" \
-            -f body="Automated permissions probe — will be deleted" \
-            -F draft=false 2>&1) && echo "SUCCESS: $RESULT" || echo "FAILED: $RESULT"
-          # Cleanup
-          RELEASE_ID=$(gh api /repos/${{ github.repository }}/releases/tags/test-permissions-probe \
-            --jq '.id' 2>/dev/null || true)
-          [ -n "$RELEASE_ID" ] && gh api "/repos/${{ github.repository }}/releases/$RELEASE_ID" \
-            --method DELETE 2>/dev/null || true
-          git push origin :refs/tags/test-permissions-probe 2>/dev/null || true
-
       - uses: googleapis/release-please-action@v4
         id: release
         with:


### PR DESCRIPTION
## Summary

- Remove the temporary non-draft release creation diagnostic step from `_release-please.yml`

## Context

The diagnostic was added in PR #105 to verify that GitHub App tokens can create published (non-draft) releases. The test succeeded — the release-please pipeline is now fully operational after fixing:
1. PR #118 stuck `autorelease: pending` label (swapped to `autorelease: tagged`)
2. Missing `permission-issues: write` on the App token (added in PR #105)

Release-please successfully created PR #144 (`chore(main): release 1.8.0`) in `claude-code-plugins`.

## Test plan

- [ ] Merge and confirm next release-please run in `claude-code-plugins` still passes without the diagnostic