### PR TITLE
chore(release-please): move config to per-repo config files

### DIFF
--- a/.github/workflows/_release-please.yml
+++ b/.github/workflows/_release-please.yml
@@ -1,7 +1,7 @@
 # Reusable: Release Please
 # Automates versioning and changelog via conventional commits.
 #
-# All release configuration is inlined as action inputs.
+# Release configuration lives in each repo's release-please-config.json.
 # Calling repos should pass secrets and permissions explicitly:
 #
 #   jobs:
@@ -19,7 +19,7 @@
 #   Calling repos must grant `contents: write` and `pull-requests: write` in the caller job permissions
 #
 # Required files in each calling repo:
-#   VERSION                         - plain-text current version (e.g. "1.2.3")
+#   release-please-config.json     - release config (release-type, changelog-sections, extra-files)
 #   .release-please-manifest.json  - release-please manifest (e.g. {"." : "1.2.3"})
 #
 # Secrets required:
@@ -67,27 +67,8 @@ jobs:
         id: release
         with:
           token: ${{ steps.app-token.outputs.token }}
-          release-type: simple
-          version-file: VERSION
-          include-v-in-tag: true
-          # Version bumps follow standard semver via conventional commits:
-          #   fix:  → patch    feat:  → minor
-          # Automated major bumps are blocked (see guard step below).
-          # Major bumps require manually editing .release-please-manifest.json.
-          # Note: `breaking:` commit type is for changelog display only.
-          changelog-types: |
-            [
-              {"type": "feat", "section": "Features"},
-              {"type": "fix", "section": "Bug Fixes"},
-              {"type": "perf", "section": "Performance"},
-              {"type": "breaking", "section": "Breaking Changes"},
-              {"type": "chore", "section": "Miscellaneous", "hidden": true},
-              {"type": "ci", "section": "CI", "hidden": true},
-              {"type": "docs", "section": "Documentation", "hidden": true},
-              {"type": "refactor", "section": "Refactoring", "hidden": true},
-              {"type": "test", "section": "Tests", "hidden": true}
-            ]
           manifest-file: .release-please-manifest.json
+          config-file: release-please-config.json
 
       - name: Find release PR number
         id: find-pr


### PR DESCRIPTION
## Summary

- Remove `version-file`, `include-v-in-tag`, and `changelog-types` inputs from the shared workflow — these are invalid for release-please-action v4 and were silently ignored
- Add explicit `config-file: release-please-config.json` input
- Update header comments to document per-repo config requirements

## Context

release-please-action v4 in manifest mode only accepts: `token`, `release-type`, `manifest-file`, `config-file`, and a few others. The removed inputs must be specified in each repo's `release-please-config.json` instead.

Companion PR in `claude-code-plugins`: adds these settings to its config file.

## Test plan

- [ ] Merge companion PR in `claude-code-plugins` first (or simultaneously)
- [ ] Verify no "Unexpected input" warnings in the next release-please run
- [ ] Verify release-please reads `release-please-config.json` correctly