### PR TITLE
chore: post-versioning cleanup and best practices improvements

### DIFF
--- a/.commitlintrc.yaml
+++ b/.commitlintrc.yaml
@@ -48,4 +48,9 @@ rules:
     - always
     - 100
 
+# NOTE: The headerPattern blocks `!` before `:` (e.g., `feat!:`), but the
+# `BREAKING CHANGE:` footer in commit bodies can still trigger major bumps.
+# Commitlint has no built-in rule to selectively block specific footers.
+# The _release-please.yml workflow guard catches this at PR time by closing
+# any release PR that proposes a major version bump.
 helpUrl: "https://www.conventionalcommits.org/"

--- a/.github/PULL_REQUEST_TEMPLATE/breaking.md
+++ b/.github/PULL_REQUEST_TEMPLATE/breaking.md
@@ -2,8 +2,8 @@
 
 ⚠️ **WARNING: This PR contains breaking changes** ⚠️
 
-<!-- PR Title Format: feat!: brief description OR breaking(scope): description -->
-<!-- Example: feat!: remove deprecated v1 API endpoints -->
+<!-- PR Title Format: breaking(scope): description -->
+<!-- Example: breaking(api): remove deprecated v1 API endpoints -->
 
 ## Breaking Changes Summary
 
@@ -90,8 +90,7 @@ See [LABELS.md](../docs/LABELS.md) for label definitions.
 
 <!-- Please confirm the following before submitting your pull request -->
 
-- [ ] PR title follows conventional commits format: `feat!: description` or `breaking(scope): description`
-- [ ] Commit body includes "BREAKING CHANGE:" section (if using feat! format)
+- [ ] PR title follows conventional commits format: `breaking(scope): description`
 - [ ] All commits are GPG signed
 - [ ] No merge commits (rebased if needed)
 - [ ] Migration path is clear and documented

--- a/.github/workflows/_nix-build.yml
+++ b/.github/workflows/_nix-build.yml
@@ -12,6 +12,8 @@ on:
         type: string
         default: "nix build .#homeConfigurations.$(whoami).activationPackage --print-build-logs"
 
+permissions: {}
+
 concurrency:
   group: nix-build-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/auto-label-issues.yml
+++ b/.github/workflows/auto-label-issues.yml
@@ -4,6 +4,8 @@ on:
   issues:
     types: [opened]
 
+permissions: {}
+
 jobs:
   label:
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,8 @@ on:
   schedule:
     - cron: '0 7 * * 0'
 
+permissions: {}
+
 jobs:
   analyze:
     name: Analyze

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ Must follow [Conventional Commits](https://www.conventionalcommits.org/):
 - `feat(api): add user authentication`
 - `fix(ui): resolve button alignment`
 - `docs(readme): update installation`
-- `feat!: remove deprecated v1 API` (breaking change)
+- `breaking(api): remove deprecated v1 API` (breaking change)
 
 ## Labels (Required per issue and PR)
 

--- a/README.md
+++ b/README.md
@@ -141,14 +141,17 @@ Standardized [pull request templates][pr-templates-docs] that enforce convention
 
 [GitHub Actions workflows][workflows-docs] for label management and reusable CI:
 
-| Workflow                | Purpose                              | Trigger              |
-| ----------------------- | ------------------------------------ | -------------------- |
-| `auto-label-issues.yml` | Apply priority/size from issue forms | Issue creation       |
-| `label-sync.yml`        | Deploy `labels.yml` to all repos     | Push to main, manual |
-| `_file-size.yml`        | Reusable: file size/line checks      | `workflow_call`      |
-| `_markdown-lint.yml`    | Reusable: markdownlint-cli2          | `workflow_call`      |
-| `_nix-build.yml`        | Reusable: Nix build (macOS)          | `workflow_call`      |
-| `_nix-validate.yml`     | Reusable: Nix flake check (Linux)    | `workflow_call`      |
+| Workflow                     | Purpose                              | Trigger                          |
+| ---------------------------- | ------------------------------------ | -------------------------------- |
+| `auto-label-issues.yml`      | Apply priority/size from issue forms | Issue creation                   |
+| `codeql.yml`                 | Code scanning (GitHub Actions)       | Push/PR to main, weekly schedule |
+| `label-sync.yml`             | Deploy `labels.yml` to all repos     | Push to main, manual             |
+| `_copilot-setup-steps.yml`   | Reusable: Copilot setup steps        | `workflow_call`                  |
+| `_file-size.yml`             | Reusable: file size/line checks      | `workflow_call`                  |
+| `_markdown-lint.yml`         | Reusable: markdownlint-cli2          | `workflow_call`                  |
+| `_nix-build.yml`             | Reusable: Nix build (macOS)          | `workflow_call`                  |
+| `_nix-validate.yml`          | Reusable: Nix flake check (Linux)    | `workflow_call`                  |
+| `_release-please.yml`        | Reusable: versioning and changelog   | `workflow_call`                  |
 
 **Reusable workflows** (prefixed with `_`) are called by other repos via
 `uses: JacobPEvans/.github/.github/workflows/_name.yml@main`.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -39,7 +39,7 @@ git checkout -b chore/update-contributing-docs
 > **Note:** The old `fix/`, `docs/`, `test/`, and `refactor/` prefixes are no longer valid.
 > Use `bugfix/` for bug fixes and `chore/` for docs, tests, and refactoring work.
 
-The `claude/` prefix is reserved for automated branches created by AI tooling.
+The `claude/` and `copilot/` prefixes are reserved for automated branches created by AI tooling.
 
 ## Signing Your Commits
 

--- a/docs/LABELS.md
+++ b/docs/LABELS.md
@@ -49,7 +49,7 @@ Unlike issues, PR labels are applied manually by the author or reviewers.
 | ---------------- | --------------------------------------- | ------------- |
 | `type:bug`       | Something isn't working                 | PATCH         |
 | `type:feature`   | New feature or request                  | MINOR         |
-| `type:breaking`  | Breaking changes                        | MAJOR         |
+| `type:breaking`  | Breaking changes                        | MAJOR (\*)    |
 | `type:docs`      | Documentation only changes              | -             |
 | `type:chore`     | Maintenance, dependencies, tooling      | -             |
 | `type:ci`        | CI/CD pipeline changes                  | -             |
@@ -57,6 +57,8 @@ Unlike issues, PR labels are applied manually by the author or reviewers.
 | `type:refactor`  | Code change with no functional change   | -             |
 | `type:perf`      | Performance improvements                | -             |
 | `type:security`  | Security vulnerability or hardening     | PATCH         |
+
+(\*) Automated major bumps are blocked. `type:breaking` changes require manually editing `.release-please-manifest.json` to set the new major version.
 
 **Note**: Type labels align with [Conventional Commits](https://www.conventionalcommits.org/) and semantic versioning to automate release management.
 


### PR DESCRIPTION
## Summary

Follow-up to the release versioning strategy changes in PRs #103 and #108. Cleans up stale references and applies best-practice improvements across workflows, documentation, and configuration:

- **Remove `feat!:` references** — The `!` suffix is now blocked by commitlint (PR #103), but AGENTS.md and the breaking change PR template still referenced it as valid syntax. Updated to use `breaking(scope): description` format exclusively.
- **Add top-level `permissions: {}`** — Defense-in-depth for `_nix-build.yml`, `codeql.yml`, and `auto-label-issues.yml`. These already had job-level permissions; this adds workflow-level restriction per CISA guidelines.
- **Document BREAKING CHANGE footer gap** — Commitlint blocks `feat!:` via headerPattern but cannot selectively block `BREAKING CHANGE:` footers (no built-in rule exists). Added comment in `.commitlintrc.yaml` documenting that the workflow guard in `_release-please.yml` is the primary defense against automated major version bumps.
- **Update README workflow table** — Added `codeql.yml`, `_copilot-setup-steps.yml`, and `_release-please.yml` entries that were missing from the workflow documentation.
- **Document `copilot/` branch prefix** — Added alongside `claude/` in CONTRIBUTING.md since it's already configured in `cchk.toml`.
- **Update LABELS.md semver mapping** — Added footnote clarifying that `type:breaking → MAJOR` requires manual version bumping via `.release-please-manifest.json` (per PR #103).

## Changes

| File | Purpose |
|------|---------|
| `.commitlintrc.yaml` | Document BREAKING CHANGE footer gap and workflow defense |
| `.github/PULL_REQUEST_TEMPLATE/breaking.md` | Remove `feat!:` references, use `breaking()` scope |
| `.github/workflows/_nix-build.yml` | Add top-level `permissions: {}` |
| `.github/workflows/auto-label-issues.yml` | Add top-level `permissions: {}` |
| `.github/workflows/codeql.yml` | Add top-level `permissions: {}` |
| `AGENTS.md` | Remove `feat!:` references, update to `breaking()` scope |
| `README.md` | Add missing workflows to documentation table |
| `docs/CONTRIBUTING.md` | Document `copilot/` branch prefix alongside `claude/` |
| `docs/LABELS.md` | Add footnote on manual major version bumping requirement |

## Related Work

- **PR #103** — Configured commitlint to block `feat!:` via headerPattern
- **PR #107** — Removed diagnostic step from `_release-please.yml`
- **PR #108** — Moved release-please config to per-repo `release-please-config.json`

## Test Plan

- [x] `actionlint` passes on all modified workflow files
- [x] `markdownlint-cli2` passes on all modified markdown files
- [x] All pre-commit hooks pass (YAML validation, spelling, link checking)
- [ ] CI passes on this PR
