### PR TITLE
feat(renovate): add trusted Terraform providers and GitHub Actions orgs to auto-merge

### DIFF
--- a/renovate-presets.json
+++ b/renovate-presets.json
@@ -40,7 +40,10 @@
         "python/**",
         "microsoft/**",
         "Azure/**",
-        "raycast/**"
+        "raycast/**",
+        "aws-actions/**",
+        "google-github-actions/**",
+        "docker/**"
       ],
       "automerge": true,
       "automergeType": "pr",
@@ -50,6 +53,19 @@
     {
       "description": "Auto-merge pre-commit hooks (minor and patch)",
       "matchManagers": ["pre-commit"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true,
+      "automergeType": "pr",
+      "automergeStrategy": "squash",
+      "minimumReleaseAge": "3 days"
+    },
+    {
+      "description": "Auto-merge trusted Terraform providers (3-day stabilization)",
+      "matchManagers": ["terraform"],
+      "matchDatasources": ["terraform-provider"],
+      "matchPackageNames": [
+        "hashicorp/*"
+      ],
       "matchUpdateTypes": ["minor", "patch"],
       "automerge": true,
       "automergeType": "pr",


### PR DESCRIPTION
## Summary

- Add `hashicorp/*` Terraform providers to auto-merge for minor and patch updates with 3-day stabilization delay
- Add `aws-actions/**`, `google-github-actions/**`, and `docker/**` to the trusted GitHub Actions auto-merge list
- Terraform provider rule is scoped to minor+patch only — majors remain blocked by the existing first rule

## Test plan

- [x] JSON validates: `python3 -m json.tool` passes
- [ ] Renovate dependency dashboard on a Terraform repo (e.g. `terraform-aws-bedrock`) recognizes the new rule
- [ ] `terraform-aws-static-website` retains its explicit `automerge: false` override (no behavioral change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)