### PR TITLE
fix: upgrade release-please default config to packages format

### DIFF
--- a/.github/workflows/_release-please.yml
+++ b/.github/workflows/_release-please.yml
@@ -61,19 +61,23 @@ jobs:
             cat > release-please-config.json << 'DEFAULTS'
           {
             "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-            "release-type": "simple",
-            "version-file": "VERSION",
-            "include-v-in-tag": true,
-            "changelog-sections": [
-              {"type": "feat", "section": "Features"},
-              {"type": "fix", "section": "Bug Fixes"},
-              {"type": "perf", "section": "Performance"},
-              {"type": "docs", "section": "Documentation", "hidden": true},
-              {"type": "chore", "section": "Miscellaneous", "hidden": true},
-              {"type": "refactor", "section": "Refactoring", "hidden": true},
-              {"type": "test", "section": "Tests", "hidden": true},
-              {"type": "ci", "section": "CI", "hidden": true}
-            ]
+            "packages": {
+              ".": {
+                "release-type": "simple",
+                "version-file": "VERSION",
+                "include-v-in-tag": true,
+                "changelog-sections": [
+                  {"type": "feat", "section": "Features"},
+                  {"type": "fix", "section": "Bug Fixes"},
+                  {"type": "perf", "section": "Performance"},
+                  {"type": "docs", "section": "Documentation", "hidden": true},
+                  {"type": "chore", "section": "Miscellaneous", "hidden": true},
+                  {"type": "refactor", "section": "Refactoring", "hidden": true},
+                  {"type": "test", "section": "Tests", "hidden": true},
+                  {"type": "ci", "section": "CI", "hidden": true}
+                ]
+              }
+            }
           }
           DEFAULTS
             echo "::notice::Using default release-please-config.json (repo has no custom config)"


### PR DESCRIPTION
## Summary
- Upgrades the auto-generated default `release-please-config.json` from flat schema to `packages` format
- Matches the canonical pattern used by claude-code-plugins (the gold standard)
- No behavioral change — release-please v4 supports both formats identically

## Context
Wave 1 of the release-please standardization effort. This should merge before Wave 2 PRs.

## Test plan
- [ ] CI passes
- [ ] After merge, repos inheriting the default still get correct release behavior

## Merge Order
This PR (Wave 1) should merge **first**. It updates the default config format for repos without custom configs.

## Related PRs (Wave 2)
- JacobPEvans/terraform-aws-bedrock#22
- JacobPEvans/kubernetes-monitoring#98
- JacobPEvans/ai-workflows#113
- JacobPEvans/secrets-sync#29
- JacobPEvans/tf-splunk-aws#75
- JacobPEvans/terraform-aws-static-website#14
- JacobPEvans/ansible-proxmox-apps#137
- JacobPEvans/ansible-splunk#99

🤖 Generated with [Claude Code](https://claude.com/claude-code)