### PR TITLE
fix: remove broken runtime config fallback

### DIFF
--- a/.github/workflows/_release-please.yml
+++ b/.github/workflows/_release-please.yml
@@ -20,9 +20,7 @@
 #
 # Repo files:
 #   .release-please-manifest.json  - REQUIRED: version manifest (e.g. {"." : "1.2.3"})
-#   release-please-config.json     - OPTIONAL: release config; a sensible default is
-#                                    generated at runtime when absent (simple release-type,
-#                                    VERSION file, v-prefixed tags, standard changelog sections)
+#   release-please-config.json     - REQUIRED: release config (must be committed to the repo)
 #
 # Secrets required:
 #   GH_ACTION_JACOBPEVANS_APP_ID  - GitHub App ID (repo-level secret)
@@ -54,34 +52,6 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v6
-
-      - name: Ensure release-please config exists
-        run: |
-          if [ ! -f release-please-config.json ]; then
-            cat > release-please-config.json << 'DEFAULTS'
-          {
-            "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-            "packages": {
-              ".": {
-                "release-type": "simple",
-                "version-file": "VERSION",
-                "include-v-in-tag": true,
-                "changelog-sections": [
-                  {"type": "feat", "section": "Features"},
-                  {"type": "fix", "section": "Bug Fixes"},
-                  {"type": "perf", "section": "Performance"},
-                  {"type": "docs", "section": "Documentation", "hidden": true},
-                  {"type": "chore", "section": "Miscellaneous", "hidden": true},
-                  {"type": "refactor", "section": "Refactoring", "hidden": true},
-                  {"type": "test", "section": "Tests", "hidden": true},
-                  {"type": "ci", "section": "CI", "hidden": true}
-                ]
-              }
-            }
-          }
-          DEFAULTS
-            echo "::notice::Using default release-please-config.json (repo has no custom config)"
-          fi
 
       - name: Generate GitHub App Token
         id: app-token


### PR DESCRIPTION
## Summary
- Remove the "Ensure release-please config exists" step from the reusable workflow
- This step creates a config file at runtime, but release-please reads from the git tree (GitHub API), not the local filesystem
- Repos without a committed config now get a clear error instead of a silent failure

## Test plan
- [ ] Verify repos WITH committed config still work
- [ ] Verify repos WITHOUT committed config get clear error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)