### PR TITLE
fix(ci): add preflight check for Actions PR approval setting

### DIFF
--- a/.github/workflows/_release-please.yml
+++ b/.github/workflows/_release-please.yml
@@ -53,6 +53,18 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Preflight - verify Actions can approve PRs
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          CAN_APPROVE=$(gh api "/repos/${{ github.repository }}/actions/permissions/workflow" \
+            --jq '.can_approve_pull_request_reviews')
+          if [ "$CAN_APPROVE" != "true" ]; then
+            echo "::error::Repository setting 'Allow GitHub Actions to create and approve pull requests' is disabled."
+            echo "::error::Enable via: gh api --method PUT /repos/${{ github.repository }}/actions/permissions/workflow -f default_workflow_permissions=read -F can_approve_pull_request_reviews=true"
+            exit 1
+          fi
+
       - name: Generate GitHub App Token
         id: app-token
         uses: actions/create-github-app-token@v3

--- a/.github/workflows/_release-please.yml
+++ b/.github/workflows/_release-please.yml
@@ -53,18 +53,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Preflight - verify Actions can approve PRs
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          CAN_APPROVE=$(gh api "/repos/${{ github.repository }}/actions/permissions/workflow" \
-            --jq '.can_approve_pull_request_reviews')
-          if [ "$CAN_APPROVE" != "true" ]; then
-            echo "::error::Repository setting 'Allow GitHub Actions to create and approve pull requests' is disabled."
-            echo "::error::Enable via: gh api --method PUT /repos/${{ github.repository }}/actions/permissions/workflow -f default_workflow_permissions=read -F can_approve_pull_request_reviews=true"
-            exit 1
-          fi
-
       - name: Generate GitHub App Token
         id: app-token
         uses: actions/create-github-app-token@v3
@@ -74,6 +62,22 @@ jobs:
           permission-contents: write
           permission-pull-requests: write
           permission-issues: write
+
+      - name: Preflight - verify Actions can approve PRs
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          if ! API_RESPONSE=$(gh api "/repos/${{ github.repository }}/actions/permissions/workflow" 2>&1); then
+            echo "::error::Failed to query Actions workflow permissions (API call failed). Verify the token has administration:read access."
+            echo "::error::API response: $API_RESPONSE"
+            exit 1
+          fi
+          CAN_APPROVE=$(echo "$API_RESPONSE" | jq -r '.can_approve_pull_request_reviews')
+          if [ "$CAN_APPROVE" != "true" ]; then
+            echo "::error::Repository setting 'Allow GitHub Actions to create and approve pull requests' is disabled."
+            echo "::error::Enable via: gh api --method PUT /repos/${{ github.repository }}/actions/permissions/workflow -F can_approve_pull_request_reviews=true"
+            exit 1
+          fi
 
       - uses: googleapis/release-please-action@v4
         id: release


### PR DESCRIPTION
## Summary
- Adds a preflight step to the reusable release-please workflow that verifies the "Allow GitHub Actions to create and approve pull requests" repository setting is enabled before proceeding
- Fails fast with a clear error message and remediation command if the setting is disabled, preventing cryptic failures during the PR approval step

## Test plan
- [ ] Verify workflow YAML is valid
- [ ] Confirm preflight step runs before the GitHub App Token generation step
- [ ] Test in a repo with the setting enabled (should pass and continue)
- [ ] Test in a repo with the setting disabled (should fail with actionable error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)