### PR TITLE
fix(renovate): fix auto-merge rules that never matched GitHub Actions

### DIFF
--- a/renovate-presets.json
+++ b/renovate-presets.json
@@ -12,9 +12,11 @@
       "automerge": false
     },
     {
-      "description": "Auto-merge JacobPEvans-owned GitHub Actions (immediate)",
-      "matchDatasources": ["github-actions"],
-      "matchPackageNames": ["JacobPEvans/**"],
+      "description": "Auto-merge all JacobPEvans-owned dependencies (immediate, all ecosystems)",
+      "matchPackageNames": [
+        "JacobPEvans/**",
+        "https://github.com/JacobPEvans/**"
+      ],
       "automerge": true,
       "automergeType": "pr",
       "automergeStrategy": "squash",
@@ -22,7 +24,7 @@
     },
     {
       "description": "Auto-merge trusted GitHub Actions (3-day stabilization)",
-      "matchDatasources": ["github-actions"],
+      "matchManagers": ["github-actions"],
       "matchPackageNames": [
         "actions/**",
         "googleapis/**",
@@ -71,15 +73,6 @@
       "automergeType": "pr",
       "automergeStrategy": "squash",
       "minimumReleaseAge": "3 days"
-    },
-    {
-      "description": "Auto-merge JacobPEvans-owned Nix flake inputs (immediate)",
-      "matchManagers": ["nix"],
-      "matchDatasources": ["git-refs"],
-      "matchPackageNames": ["https://github.com/JacobPEvans/**"],
-      "automerge": true,
-      "automergeType": "pr",
-      "automergeStrategy": "squash"
     },
     {
       "description": "Auto-merge trusted Nix flake inputs (immediate, CI-gated)",


### PR DESCRIPTION
## Summary

- **Consolidated** two JacobPEvans-specific rules (GitHub Actions + Nix flakes) into one universal rule that matches all ecosystems by package name only — covers current and future ecosystems
- **Fixed** trusted GitHub Actions rule: changed `matchDatasources: ["github-actions"]` to `matchManagers: ["github-actions"]` — `github-actions` is a manager name, not a datasource (Renovate internally uses `github-tags` datasource)

## Root Cause

Auto-merge has **never worked** for any Renovate GitHub Actions PR across the org. Every PR showed "Automerge: Disabled by config" because the rules used `matchDatasources: ["github-actions"]`, which matches nothing.

## Test plan

- [ ] After Renovate picks up the new config, existing open Renovate PRs should show "Automerge: Enabled"
- [ ] Verify trusted 3rd-party actions (e.g., `actions/checkout`) get auto-merge with 3-day stabilization
- [ ] Verify JacobPEvans-owned deps across all ecosystems get immediate auto-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)