### PR TITLE
fix: remove dead allowedPostUpgradeCommands from shared preset

### DIFF
--- a/renovate-presets.json
+++ b/renovate-presets.json
@@ -2,9 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "description": "JacobPEvans org-wide Renovate preset",
   "platformAutomerge": true,
-  "allowedPostUpgradeCommands": [
-    "^nix flake check --no-build$"
-  ],
   "packageRules": [
     {
       "description": "Never auto-merge major updates - require human review (overridden by trusted package rules below)",


### PR DESCRIPTION
## Summary

- Remove `allowedPostUpgradeCommands` from org-wide Renovate preset — this is a self-hosted-only option that is silently ignored by the hosted Mend Renovate GitHub App

## Changes

Removed 3 lines from `renovate-presets.json`:
```json
"allowedPostUpgradeCommands": [
  "^nix flake check --no-build$"
]
```

Part of a cross-repo fix:
- JacobPEvans/nix-darwin#886 — Remove broken `postUpgradeTasks` and consolidate configs
- JacobPEvans/JacobPEvans#21 — Add missing shared preset extension

## Test Plan

- [ ] Verify other repos' Renovate PRs still work correctly (this removes dead config, so no impact expected)
- [ ] Check Dependency Dashboard issues across repos for config warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
