### PR TITLE
fix: use safe arithmetic in file-size workflow

### DIFF
--- a/.github/workflows/_file-size.yml
+++ b/.github/workflows/_file-size.yml
@@ -87,10 +87,10 @@ jobs:
 
             if [ "$size" -gt "$limit" ]; then
               echo "::error file=$f::$((size/1024))KB exceeds $((limit/1024))KB limit"
-              ((errors++))
+              errors=$((errors + 1))
             elif [ "$size" -gt "$warn_threshold" ]; then
               echo "::warning file=$f::$((size/1024))KB exceeds $((warn_threshold/1024))KB recommended"
-              ((warnings++))
+              warnings=$((warnings + 1))
             fi
           done < <(find . -type f \( "${name_args[@]}" \) \
             -not -path "./.git/*" -not -path "./node_modules/*" -not -path "./result/*" \


### PR DESCRIPTION
## Summary

- Replaces `((errors++))` with `errors=$((errors + 1))` to avoid bash arithmetic exit code bug
- `((0++))` evaluates to 0 (falsy), returning exit code 1 under `set -eo pipefail`
- This caused the File Size check to fail on the first warning-only file

## Test plan

- [ ] nix-darwin CI passes after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)