### PR TITLE
fix: include filenames in file-size output and add auth docs

### DIFF
--- a/.github/workflows/_file-size.yml
+++ b/.github/workflows/_file-size.yml
@@ -86,10 +86,10 @@ jobs:
             fi
 
             if [ "$size" -gt "$limit" ]; then
-              echo "::error file=$f::$((size/1024))KB exceeds $((limit/1024))KB limit"
+              echo "::error file=$f::$f is $((size/1024))KB (exceeds $((limit/1024))KB limit)"
               errors=$((errors + 1))
             elif [ "$size" -gt "$warn_threshold" ]; then
-              echo "::warning file=$f::$((size/1024))KB exceeds $((warn_threshold/1024))KB recommended"
+              echo "::warning file=$f::$f is $((size/1024))KB (exceeds $((warn_threshold/1024))KB recommended)"
               warnings=$((warnings + 1))
             fi
           done < <(find . -type f \( "${name_args[@]}" \) \

--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -1,0 +1,55 @@
+# Authentication & Secrets Management
+
+Cross-repository reference for how credentials are managed across the JacobPEvans infrastructure.
+
+## Secret Providers
+
+### Bitwarden Secrets Manager
+
+- **Used by**: nix-darwin, nix-ai
+- **Purpose**: Application secrets, API tokens
+- **Access**: Via `bws` CLI, integrated into Nix configuration
+
+### Doppler
+
+- **Used by**: terraform-proxmox, terraform-aws, ansible-proxmox, ansible-proxmox-apps, ansible-splunk
+- **Purpose**: Infrastructure secrets (API keys, credentials)
+- **Access**: Via `doppler run --` prefix on commands
+
+### aws-vault
+
+- **Used by**: terraform-aws, terraform-proxmox, terraform-aws-bedrock
+- **Purpose**: AWS credential management with MFA/session tokens
+- **Access**: Via `aws-vault exec <profile> --` prefix
+- **Detailed guide**: See terraform-proxmox `docs/aws-vault-terraform.md`
+
+### SOPS/age
+
+- **Used by**: nix-devenv
+- **Purpose**: Encrypted secrets in git (dev shell configs)
+- **Access**: Via `SOPS_AGE_KEY_FILE` environment variable (path, not secret — safe in `.envrc`)
+
+### SSH Keys
+
+- **Used by**: terraform-proxmox, ansible-*
+- **Purpose**: Proxmox node access, VM provisioning
+- **Access**: Via `ssh-agent` or direct key path variables
+
+### GitHub App Tokens
+
+- **Used by**: CI/CD workflows across all repos
+- **Purpose**: Cross-repo automation, release-please, CI triggers
+- **Access**: Via `actions/create-github-app-token` in workflows
+
+### macOS Keychain
+
+- **Used by**: nix-darwin
+- **Purpose**: HuggingFace tokens, service credentials
+- **Access**: Via `security find-generic-password` in activation scripts
+
+## Principles
+
+1. **Never hardcode secrets** — use providers above
+2. **Paths are not secrets** — `SOPS_AGE_KEY_FILE`, SSH key paths are safe to commit in `.envrc`
+3. **Provider per context** — use the right provider for the right repo (see table above)
+4. **CI uses GitHub App tokens** — not PATs, not deploy keys


### PR DESCRIPTION
## Summary

- File-size workflow annotations now include the filename in the message text, making errors/warnings visible in GitHub Actions logs (not just the annotation sidebar)
- Added `docs/AUTHENTICATION.md` documenting how secrets and credentials are managed across all JacobPEvans repos

## Test plan

- [ ] Verify file-size workflow annotations show filenames in CI logs
- [ ] Review AUTHENTICATION.md for accuracy against current repo configurations

🤖 Generated with [Claude Code](https://claude.com/claude-code)