### PR TITLE
fix: add bpg/* as trusted Terraform provider for Renovate automerge

### DIFF
--- a/renovate-presets.json
+++ b/renovate-presets.json
@@ -59,11 +59,12 @@
       "minimumReleaseAge": "3 days"
     },
     {
-      "description": "Auto-merge trusted Terraform providers (3-day stabilization)",
+      "description": "Auto-merge trusted Terraform providers (3-day stabilization, minor/patch only)",
       "matchManagers": ["terraform"],
       "matchDatasources": ["terraform-provider"],
       "matchPackageNames": [
-        "hashicorp/*"
+        "hashicorp/*",
+        "bpg/*"
       ],
       "matchUpdateTypes": ["minor", "patch"],
       "automerge": true,


### PR DESCRIPTION
## Summary
- Adds `bpg/*` to the trusted Terraform providers rule in org-wide `renovate-presets.json`
- BPG Proxmox provider minor/patch updates will now automerge with 3-day stabilization
- Updated rule description to clarify "minor/patch only" constraint

## Changes
- `renovate-presets.json`: Added `bpg/*` to `matchPackageNames` in the trusted Terraform providers rule

## Related
- Unblocks automerge for [terraform-proxmox#204](https://github.com/JacobPEvans/terraform-proxmox/pull/204)
