### PR TITLE
fix(release-please): always enable auto-merge on release PRs

### DIFF
--- a/.github/workflows/_release-please.yml
+++ b/.github/workflows/_release-please.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Find release PR number
         id: find-pr
-        if: steps.release.outputs.prs_created == 'true'
+        if: '!cancelled()'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           BASE_BRANCH: ${{ github.ref_name }}
@@ -81,7 +81,7 @@ jobs:
           echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
 
       - name: Guard against automated major bumps
-        if: steps.find-pr.outputs.number != ''
+        if: "!cancelled() && steps.find-pr.outputs.number != ''"
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ steps.find-pr.outputs.number }}
@@ -108,14 +108,14 @@ jobs:
           fi
 
       - name: Enable auto-merge for release PR
-        if: steps.find-pr.outputs.number != ''
+        if: "!cancelled() && steps.find-pr.outputs.number != ''"
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ steps.find-pr.outputs.number }}
         run: gh pr merge "$PR_NUMBER" --auto --squash
 
       - name: Approve release PR
-        if: steps.find-pr.outputs.number != ''
+        if: "!cancelled() && steps.find-pr.outputs.number != ''"
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ steps.find-pr.outputs.number }}


### PR DESCRIPTION
## Summary

- Remove prs_created gate from find-pr step — now always searches for an open release PR on every push to main
- Add !cancelled() to all downstream steps so they execute even when release-please-action fails

## Root Cause

nix-darwin PR #899 was not auto-merged because:

1. find-pr only ran when prs_created == true — only set when release-please creates a new PR, not when it updates an existing one
2. The most recent release-please run failed with a stale label node ID error, and all downstream steps were skipped

## Test plan

- [ ] Verify PR #899 in nix-darwin gets auto-merge enabled
- [ ] On next release cycle, confirm full flow works
- [ ] Verify !cancelled() doesn't cause issues when no release PR exists