### PR TITLE
fix(release-please): enforce always-bump-minor centrally via shared workflow

### DIFF
--- a/.commitlintrc.yaml
+++ b/.commitlintrc.yaml
@@ -49,8 +49,8 @@ rules:
     - 100
 
 # NOTE: Two layers prevent automated major bumps:
-#   1. release-please config: "versioning": "always-bump-minor" in every repo's
-#      release-please-config.json (ignores BREAKING CHANGE footers entirely)
+#   1. Shared workflow: _release-please.yml injects "versioning": "always-bump-minor"
+#      into every repo's config at runtime (ignores BREAKING CHANGE footers entirely)
 #   2. Commitlint: headerPattern above blocks `!` before `:` (e.g., `feat!:`)
 # Major version bumps are human-initiated only via .release-please-manifest.json.
 helpUrl: "https://www.conventionalcommits.org/"

--- a/.commitlintrc.yaml
+++ b/.commitlintrc.yaml
@@ -50,7 +50,7 @@ rules:
 
 # NOTE: Two layers prevent automated major bumps:
 #   1. Shared workflow: _release-please.yml injects "versioning": "always-bump-minor"
-#      into every repo's config at runtime (ignores BREAKING CHANGE footers entirely)
+#      into every repo's config at runtime (prevents major bumps even with BREAKING CHANGE footers)
 #   2. Commitlint: headerPattern above blocks `!` before `:` (e.g., `feat!:`)
 # Major version bumps are human-initiated only via .release-please-manifest.json.
 helpUrl: "https://www.conventionalcommits.org/"

--- a/.commitlintrc.yaml
+++ b/.commitlintrc.yaml
@@ -48,9 +48,9 @@ rules:
     - always
     - 100
 
-# NOTE: The headerPattern blocks `!` before `:` (e.g., `feat!:`), but the
-# `BREAKING CHANGE:` footer in commit bodies can still trigger major bumps.
-# Commitlint has no built-in rule to selectively block specific footers.
-# The _release-please.yml workflow guard catches this at PR time by closing
-# any release PR that proposes a major version bump.
+# NOTE: Two layers prevent automated major bumps:
+#   1. release-please config: "versioning": "always-bump-minor" in every repo's
+#      release-please-config.json (ignores BREAKING CHANGE footers entirely)
+#   2. Commitlint: headerPattern above blocks `!` before `:` (e.g., `feat!:`)
+# Major version bumps are human-initiated only via .release-please-manifest.json.
 helpUrl: "https://www.conventionalcommits.org/"

--- a/.github/workflows/_release-please.yml
+++ b/.github/workflows/_release-please.yml
@@ -20,8 +20,8 @@
 #
 # Repo files:
 #   .release-please-manifest.json  - REQUIRED: version manifest (e.g. {"." : "1.2.3"})
-#   release-please-config.json     - REQUIRED: must include "versioning": "always-bump-minor"
-#                                    in every package to prevent automated major bumps
+#   release-please-config.json     - REQUIRED: release config (repo-specific settings only;
+#                                    versioning policy is enforced by this workflow centrally)
 #
 # Secrets required:
 #   GH_ACTION_JACOBPEVANS_APP_ID  - GitHub App ID (repo-level secret)
@@ -53,6 +53,15 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v6
+
+      # Org policy: automated major version bumps are forbidden.
+      # This overrides any repo-level versioning config to ensure release-please
+      # never computes a major bump, regardless of BREAKING CHANGE footers.
+      # Major bumps are human-initiated only via .release-please-manifest.json.
+      - name: Enforce org-wide versioning policy (block automated major bumps)
+        run: |
+          jq '.packages[].versioning = "always-bump-minor"' release-please-config.json > /tmp/rp.json
+          mv /tmp/rp.json release-please-config.json
 
       - name: Generate GitHub App Token
         id: app-token

--- a/.github/workflows/_release-please.yml
+++ b/.github/workflows/_release-please.yml
@@ -20,7 +20,8 @@
 #
 # Repo files:
 #   .release-please-manifest.json  - REQUIRED: version manifest (e.g. {"." : "1.2.3"})
-#   release-please-config.json     - REQUIRED: release config (must be committed to the repo)
+#   release-please-config.json     - REQUIRED: must include "versioning": "always-bump-minor"
+#                                    in every package to prevent automated major bumps
 #
 # Secrets required:
 #   GH_ACTION_JACOBPEVANS_APP_ID  - GitHub App ID (repo-level secret)
@@ -79,33 +80,6 @@ jobs:
         run: |
           PR_NUMBER=$(gh pr list --head "release-please--branches--${BASE_BRANCH}" --json number --jq '.[0].number // empty')
           echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
-
-      - name: Guard against automated major bumps
-        if: "!cancelled() && steps.find-pr.outputs.number != ''"
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          PR_NUMBER: ${{ steps.find-pr.outputs.number }}
-        run: |
-          # Get proposed version from the release PR title
-          PR_TITLE=$(gh pr view "$PR_NUMBER" --json title --jq '.title')
-          PROPOSED_VERSION=$(echo "$PR_TITLE" | grep -oP '\d+\.\d+\.\d+' | head -1)
-
-          if [ -z "$PROPOSED_VERSION" ]; then
-            echo "::warning::Could not extract version from release PR title: $PR_TITLE"
-            exit 0
-          fi
-
-          PROPOSED_MAJOR=$(echo "$PROPOSED_VERSION" | cut -d. -f1)
-
-          # Get current version from manifest
-          CURRENT_VERSION=$(jq -r '."."' .release-please-manifest.json)
-          CURRENT_MAJOR=$(echo "$CURRENT_VERSION" | cut -d. -f1)
-
-          if [ "$PROPOSED_MAJOR" != "$CURRENT_MAJOR" ]; then
-            echo "::error::Automated major bump blocked ($CURRENT_VERSION -> $PROPOSED_VERSION). Major bumps require manually editing .release-please-manifest.json."
-            gh pr close "$PR_NUMBER" --comment "Automated major version bump blocked ($CURRENT_VERSION -> $PROPOSED_VERSION). Major bumps are human-initiated only. To perform a major bump, manually edit .release-please-manifest.json and push to main."
-            exit 1
-          fi
 
       - name: Enable auto-merge for release PR
         if: "!cancelled() && steps.find-pr.outputs.number != ''"


### PR DESCRIPTION
## Summary

- Removes the 25-line custom "Guard against automated major bumps" script from `_release-please.yml` (reactive workaround that closed release PRs after creation)
- Adds centralized jq injection that forces `versioning: always-bump-minor` on all packages at runtime, before release-please reads the config
- Updates comments in workflow and commitlint to document the centralized approach and clarify BREAKING CHANGE handling

This establishes a **single source of truth** for org versioning policy. Only `versioning` is overridden — all other repo-specific config (`release-type`, `extra-files`, `changelog-sections`, etc.) passes through untouched. Repos retain full control over everything except the one field that's org policy.

## Changes

- `.github/workflows/_release-please.yml` - Removed custom guard script, added jq injection step that centralizes versioning policy
- `.commitlintrc.yaml` - Updated comments to clarify that `always-bump-minor` prevents major version bumps while still detecting BREAKING CHANGE footers for changelog generation

## Test plan

- [ ] Confirm `jq` injection step runs in workflow logs after merge
- [ ] Push a `BREAKING CHANGE:` commit to any repo and verify minor (not major) bump PR
- [ ] Verify repos without `versioning` in their config still get the override

🤖 Generated with [Claude Code](https://claude.com/claude-code)
