### PR TITLE
fix: add HuggingFace as trusted PyPI org for Renovate automerge

### DIFF
--- a/renovate-presets.json
+++ b/renovate-presets.json
@@ -73,6 +73,16 @@
       "minimumReleaseAge": "3 days"
     },
     {
+      "description": "Auto-merge trusted PyPI packages from HuggingFace (3-day stabilization, minor/patch only)",
+      "matchDatasources": ["pypi"],
+      "matchSourceUrls": ["https://github.com/huggingface/**"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true,
+      "automergeType": "pr",
+      "automergeStrategy": "squash",
+      "minimumReleaseAge": "3 days"
+    },
+    {
       "description": "Auto-merge trusted Nix flake inputs (immediate, CI-gated)",
       "matchManagers": ["nix"],
       "matchDatasources": ["git-refs"],


### PR DESCRIPTION
## Summary

- Adds a `matchSourceUrls` rule to `renovate-presets.json` for the HuggingFace GitHub org
- All HuggingFace PyPI packages (huggingface-hub, transformers, tokenizers, etc.) now auto-merge on minor/patch with 3-day soak
- Fixes nix-ai #316 which should have auto-merged but had no matching trust rule

## Test plan

- [ ] Verify Renovate picks up automerge flag on JacobPEvans/nix-ai#316 after merge
- [ ] Confirm with `gh pr view 316 --repo JacobPEvans/nix-ai --json autoMergeRequest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)