### PR TITLE
fix(renovate): trust GitHub-owned actions for major auto-merge

### DIFF
--- a/renovate-presets.json
+++ b/renovate-presets.json
@@ -20,7 +20,7 @@
       "minimumReleaseAge": "0 days"
     },
     {
-      "description": "Auto-merge trusted GitHub Actions (3-day stabilization, minor/patch only)",
+      "description": "Auto-merge trusted GitHub Actions including major (3-day stabilization)",
       "matchManagers": ["github-actions"],
       "matchPackageNames": [
         "actions/**",
@@ -44,16 +44,6 @@
         "google-github-actions/**",
         "docker/**"
       ],
-      "matchUpdateTypes": ["minor", "patch"],
-      "automerge": true,
-      "automergeType": "pr",
-      "automergeStrategy": "squash",
-      "minimumReleaseAge": "3 days"
-    },
-    {
-      "description": "Auto-merge GitHub-owned Actions including major (most trusted org)",
-      "matchManagers": ["github-actions"],
-      "matchPackageNames": ["actions/**", "github/**"],
       "matchUpdateTypes": ["major", "minor", "patch"],
       "automerge": true,
       "automergeType": "pr",

--- a/renovate-presets.json
+++ b/renovate-presets.json
@@ -50,6 +50,16 @@
       "minimumReleaseAge": "3 days"
     },
     {
+      "description": "Auto-merge GitHub-owned Actions including major (most trusted org)",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": ["actions/**", "github/**"],
+      "matchUpdateTypes": ["major", "minor", "patch"],
+      "automerge": true,
+      "automergeType": "pr",
+      "automergeStrategy": "squash",
+      "minimumReleaseAge": "3 days"
+    },
+    {
       "description": "Auto-merge pre-commit hooks (minor and patch)",
       "matchManagers": ["pre-commit"],
       "matchUpdateTypes": ["minor", "patch"],

--- a/renovate-presets.json
+++ b/renovate-presets.json
@@ -20,7 +20,7 @@
       "minimumReleaseAge": "0 days"
     },
     {
-      "description": "Auto-merge trusted GitHub Actions (3-day stabilization)",
+      "description": "Auto-merge trusted GitHub Actions (3-day stabilization, minor/patch only)",
       "matchManagers": ["github-actions"],
       "matchPackageNames": [
         "actions/**",
@@ -44,6 +44,7 @@
         "google-github-actions/**",
         "docker/**"
       ],
+      "matchUpdateTypes": ["minor", "patch"],
       "automerge": true,
       "automergeType": "pr",
       "automergeStrategy": "squash",


### PR DESCRIPTION
## Summary

- Adds a new Renovate packageRule that enables major version auto-merge for `actions/**` and `github/**` GitHub Actions
- These are GitHub's own orgs and the most trusted action sources — major bumps (e.g., actions/checkout v4 to v5) are safe to auto-merge
- Retains 3-day stabilization window for safety
- The existing trusted actions rule continues to handle minor/patch for all listed orgs; this new rule layers on top to additionally allow major for the two GitHub-owned orgs

## How Renovate resolves this

Renovate applies packageRules in order — later rules override earlier ones. The flow:

1. Rule 1 blocks all major auto-merges (`automerge: false`)
2. The existing trusted actions rule auto-merges minor/patch for all trusted orgs (no `matchUpdateTypes` = defaults to minor/patch since rule 1 blocks major)
3. **This new rule** explicitly matches `major`, `minor`, `patch` for `actions/**` and `github/**`, overriding rule 1's major block

## Test plan

- [ ] Verify `jq . renovate-presets.json` passes (validated locally)
- [ ] Confirm Renovate dry-run shows major PRs for `actions/**` and `github/**` would auto-merge
- [ ] Verify other trusted orgs still block on major updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)