### PR TITLE
feat(renovate): add annotation-based customManager for Nix packages

### DIFF
--- a/renovate-presets.json
+++ b/renovate-presets.json
@@ -2,6 +2,16 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "description": "JacobPEvans org-wide Renovate preset",
   "platformAutomerge": true,
+  "customManagers": [
+    {
+      "description": "Nix version pins annotated with renovate comments",
+      "customType": "regex",
+      "fileMatch": ["\\.nix$"],
+      "matchStrings": [
+        "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)\\n\\s*\\S+\\s*=\\s*\"(?<currentValue>[^\"]+)\";"
+      ]
+    }
+  ],
   "packageRules": [
     {
       "description": "Never auto-merge major updates - require human review (overridden by trusted package rules below)",
@@ -102,6 +112,23 @@
       "automerge": true,
       "automergeType": "pr",
       "automergeStrategy": "squash"
+    },
+    {
+      "description": "GitHub releases use v-prefixed tags for custom Nix packages",
+      "matchDatasources": ["github-releases"],
+      "matchManagers": ["custom.regex"],
+      "extractVersion": "^v(?<version>.*)$"
+    },
+    {
+      "description": "Auto-merge trusted PyPI packages from HuggingFace (custom managers)",
+      "matchDatasources": ["pypi"],
+      "matchManagers": ["custom.regex"],
+      "matchPackageNames": ["huggingface-hub", "huggingface-mcp-server"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true,
+      "automergeType": "pr",
+      "automergeStrategy": "squash",
+      "minimumReleaseAge": "3 days"
     }
   ]
 }

--- a/renovate-presets.json
+++ b/renovate-presets.json
@@ -8,7 +8,7 @@
       "customType": "regex",
       "fileMatch": ["\\.nix$"],
       "matchStrings": [
-        "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)\\n\\s*\\S+\\s*=\\s*\"(?<currentValue>[^\"]+)\";"
+        "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)\\r?\\n\\s*\\S+\\s*=\\s*\"(?<currentValue>[^\"]+)\";"
       ]
     }
   ],
@@ -117,7 +117,7 @@
       "description": "GitHub releases use v-prefixed tags for custom Nix packages",
       "matchDatasources": ["github-releases"],
       "matchManagers": ["custom.regex"],
-      "extractVersion": "^v(?<version>.*)$"
+      "extractVersion": "^v(?<version>.+)$"
     },
     {
       "description": "Auto-merge trusted PyPI packages from HuggingFace (custom managers)",


### PR DESCRIPTION
## Summary
- Add org-wide `customManagers` regex entry so any `.nix` file can opt version pins into Renovate detection with a one-line annotation comment
- Add `extractVersion` rule for v-prefixed GitHub release tags used by custom Nix packages
- Add HuggingFace auto-merge trust rule for `custom.regex` manager matches (using `matchPackageNames` since regex managers don't carry source URL metadata)

## How it works
Any `.nix` file across JacobPEvans repos can now opt a version pin into Renovate detection by adding one comment:

```nix
# renovate: datasource=github-releases depName=owner/repo
version = "1.2.3";
```

Annotation-based (not auto-detection) to avoid false positives on arbitrary Nix string literals.

## Changes
- `renovate-presets.json`: Added `customManagers` array with regex pattern matching `# renovate:` annotation comments
- `renovate-presets.json`: Added `extractVersion` packageRule for `github-releases` + `custom.regex` to strip `v` prefix
- `renovate-presets.json`: Added HuggingFace trust rule scoped to `custom.regex` manager with `matchPackageNames`
- Applied review feedback: tightened `extractVersion` from `.*` to `.+`, added CRLF tolerance in `matchStrings`

## Test plan
- [x] Valid JSON (validated with `jq`)
- [x] CodeQL clean
- [ ] Verify Renovate detects annotated packages after merge (requires per-repo annotation PRs)
