### PR TITLE
fix(security): harden Renovate preset — 3-day stabilization for Nix, remove aquasecurity

### DIFF
--- a/renovate-presets.json
+++ b/renovate-presets.json
@@ -40,7 +40,6 @@
         "DeterminateSystems/**",
         "peter-evans/**",
         "DavidAnson/**",
-        "aquasecurity/**",
         "dorny/**",
         "github/**",
         "softprops/**",
@@ -111,7 +110,8 @@
       ],
       "automerge": true,
       "automergeType": "pr",
-      "automergeStrategy": "squash"
+      "automergeStrategy": "squash",
+      "minimumReleaseAge": "3 days"
     },
     {
       "description": "GitHub releases use v-prefixed tags for custom Nix packages",

--- a/renovate-presets.json
+++ b/renovate-presets.json
@@ -93,7 +93,7 @@
       "minimumReleaseAge": "3 days"
     },
     {
-      "description": "Auto-merge trusted Nix flake inputs (immediate, CI-gated)",
+      "description": "Auto-merge trusted Nix flake inputs (3-day stabilization, CI-gated)",
       "matchManagers": ["nix"],
       "matchDatasources": ["git-refs"],
       "matchPackageNames": [


### PR DESCRIPTION
## Summary

Harden org-wide Renovate preset in response to the LiteLLM/TeamPCP supply-chain attack (March 19, 2026):

- Add 3-day `minimumReleaseAge` to trusted Nix flake inputs — provides a stabilization window before auto-merge, matching the existing standard across GitHub Actions, pre-commit, Terraform, and PyPI rules
- Remove `aquasecurity/**` from trusted GitHub Actions list — same threat actor as the LiteLLM compromise
- Update Nix flake rule description to reflect the new stabilization policy

## Changes

- `renovate-presets.json`: Remove `aquasecurity/**` from `matchPackageNames` in trusted GitHub Actions rule
- `renovate-presets.json`: Add `"minimumReleaseAge": "3 days"` to Nix flake inputs rule
- `renovate-presets.json`: Update description from "immediate, CI-gated" to "3-day stabilization, CI-gated"

## Test plan

- [x] JSON validates cleanly (`jq .`)
- [x] CodeQL passes (Analyze actions + CodeQL check)
- [x] Renovate dashboard should show stabilization days for Nix inputs after merge

Related: #21, #63
