### PR TITLE
feat(security): add SECURITY.md, pip-audit and OSV scanner workflows

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -37,7 +37,11 @@
     "narinfo",
     "nixpkgs",
     "Anson",
-    "pipefail"
+    "pipefail",
+    "zizmor",
+    "Zizmor",
+    "endgroup",
+    "lockfiles"
   ],
   "ignorePaths": [
     ".git",

--- a/.github/workflows/_osv-scan.yml
+++ b/.github/workflows/_osv-scan.yml
@@ -1,0 +1,26 @@
+# Multi-ecosystem lockfile vulnerability scanning via Google OSV
+#
+# Reusable workflow — called from repo-level ci-gate.yml files.
+# Scans lockfiles (uv.lock, package-lock.json, .terraform.lock.hcl, etc.)
+# for known vulnerabilities across all supported ecosystems.
+name: OSV Vulnerability Scan
+
+on:
+  workflow_call: {}
+
+permissions:
+  contents: read
+
+jobs:
+  osv-scan:
+    name: OSV Scanner
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Run OSV Scanner
+        uses: google/osv-scanner-action/osv-scanner-action@v2
+        with:
+          scan-args: |-
+            --recursive
+            .

--- a/.github/workflows/_osv-scan.yml
+++ b/.github/workflows/_osv-scan.yml
@@ -3,10 +3,14 @@
 # Reusable workflow — called from repo-level ci-gate.yml files.
 # Scans lockfiles (uv.lock, package-lock.json, .terraform.lock.hcl, etc.)
 # for known vulnerabilities across all supported ecosystems.
-name: OSV Vulnerability Scan
+name: _osv-scan
 
 on:
   workflow_call: {}
+
+concurrency:
+  group: osv-scan-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/_python-security.yml
+++ b/.github/workflows/_python-security.yml
@@ -26,8 +26,10 @@ jobs:
         uses: astral-sh/setup-uv@v6
 
       - name: Audit Python dependencies
+        env:
+          PYTHON_DIRS: ${{ inputs.python-dirs }}
         run: |
-          for dir in ${{ inputs.python-dirs }}; do
+          for dir in $PYTHON_DIRS; do
             echo "::group::Scanning $dir"
             cd "$GITHUB_WORKSPACE/$dir"
             uv venv .venv

--- a/.github/workflows/_python-security.yml
+++ b/.github/workflows/_python-security.yml
@@ -2,7 +2,7 @@
 #
 # Reusable workflow — called from repo-level ci-gate.yml files.
 # Scans Python projects for known CVEs in resolved dependencies.
-name: Python Security Scan
+name: _python-security
 
 on:
   workflow_call:
@@ -11,6 +11,10 @@ on:
         description: 'Space-separated list of directories containing pyproject.toml'
         required: true
         type: string
+
+concurrency:
+  group: python-security-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -32,11 +36,7 @@ jobs:
           for dir in $PYTHON_DIRS; do
             echo "::group::Scanning $dir"
             cd "$GITHUB_WORKSPACE/$dir"
-            uv venv .venv
-            . .venv/bin/activate
-            uv pip install .
-            uv pip install pip-audit
-            pip-audit --progress-spinner=off --desc
-            deactivate
+            uv export --format requirements-txt --output-file requirements.txt --locked
+            uvx pip-audit --progress-spinner=off --desc -r requirements.txt
             echo "::endgroup::"
           done

--- a/.github/workflows/_python-security.yml
+++ b/.github/workflows/_python-security.yml
@@ -1,0 +1,40 @@
+# Python dependency vulnerability scanning via pip-audit
+#
+# Reusable workflow — called from repo-level ci-gate.yml files.
+# Scans Python projects for known CVEs in resolved dependencies.
+name: Python Security Scan
+
+on:
+  workflow_call:
+    inputs:
+      python-dirs:
+        description: 'Space-separated list of directories containing pyproject.toml'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  pip-audit:
+    name: pip-audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Audit Python dependencies
+        run: |
+          for dir in ${{ inputs.python-dirs }}; do
+            echo "::group::Scanning $dir"
+            cd "$GITHUB_WORKSPACE/$dir"
+            uv venv .venv
+            . .venv/bin/activate
+            uv pip install .
+            uv pip install pip-audit
+            pip-audit --progress-spinner=off --desc
+            deactivate
+            echo "::endgroup::"
+          done

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,133 @@
+# Security Policy
+
+## Reporting Vulnerabilities
+
+To report a security vulnerability, use
+[GitHub's private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability)
+on the affected repository. Do not open a public issue for security vulnerabilities.
+
+For critical vulnerabilities affecting multiple repositories, report to the
+[.github repository](https://github.com/JacobPEvans/.github/security/advisories/new).
+
+## Dependency Trust Tiers
+
+All automated dependency updates follow a tiered trust model enforced by
+[Renovate](https://docs.renovatebot.com/) via `renovate-presets.json`:
+
+| Tier | Scope | Stabilization | Auto-merge | Rationale |
+| ------ | ------- | --------------- | ------------ | ----------- |
+| **Always Trusted** | `JacobPEvans/**` (self-owned repos) | 0 days | Yes, CI-gated | Full code review and commit signing control |
+| **Trusted, Wait** | GitHub Actions, Terraform, PyPI, pre-commit hooks | 3 days | Minor/patch auto; major manual | Established orgs; strong security posture |
+| **Trusted Nix** | `NixOS/*`, `nix-community/*`, `cachix/*`, `DeterminateSystems/*` | 3 days | Yes, CI-gated | Community-monitored, commit-pinned (immutable) |
+| **Default** | All other external dependencies | 3 days | No | Requires manual review before merge |
+
+### Version Pinning Strategy
+
+| Source | Strategy |
+| -------- | ---------- |
+| JacobPEvans self-references | `@main` or major version tag — never SHA or minor/patch pins |
+| Trusted GitHub Actions | Semantic version tags (e.g., `@v6`) |
+| External/untrusted GitHub Actions | SHA commit hash pins |
+| Nix flake inputs | Branch-pinned to stable releases (e.g., `nixpkgs-25.11-darwin`) |
+| Python packages (pyproject.toml) | Lower-bound with `>=`, managed by Renovate with 3-day soak |
+| Python tool installs (uv) | Exact pin with `==`, managed by Renovate custom regex |
+
+## Dependency Update Vectors
+
+Dependencies enter the ecosystem through multiple channels. Each has different
+protections:
+
+### Renovate PRs (Managed)
+
+Primary update mechanism. Enforces stabilization delays, CI gates, and repository
+rulesets before merge. All repos extend the centralized `renovate-presets.json`.
+
+### `/flake-rebuild` Command (Managed)
+
+The approved method for manually updating Nix flake inputs. Enforces:
+
+- Feature branch isolation (never commits to main)
+- Quality validation (fmt, statix, deadnix, flake check, darwin-rebuild)
+- CI gating via auto-merge (all required status checks must pass)
+
+**Warning**: Running raw `nix flake update && darwin-rebuild switch` bypasses all
+protections. Workflow rules forbid committing directly to main, which mitigates
+but does not eliminate local execution risk.
+
+### Homebrew (`brew autoupdate`) — Accepted Risk
+
+Homebrew packages have NO version pinning in nix-darwin configuration and NO
+Renovate tracking (Renovate cannot manage Homebrew in Nix files). The `brew
+autoupdate` LaunchAgent runs every 30 hours.
+
+**Why this is accepted**: Homebrew-core has significantly more review rigor than
+PyPI or npm. All formulae are open-source and community-reviewed. Bottles are
+built by Homebrew's CI infrastructure, not package authors. Supply-chain
+compromises in homebrew-core are extremely rare.
+
+### `uv tool install` in Activation Scripts (Managed)
+
+Python tools installed during `darwin-rebuild switch` are pinned to exact
+versions (`==`) and tracked by Renovate via custom regex managers. Updates go
+through the standard 3-day stabilization pipeline.
+
+## Security Scanning
+
+| Tool | Scope | Integration |
+| ------ | ------- | ------------- |
+| **CodeQL** | GitHub Actions YAML | `codeql.yml` (org-wide) |
+| **pip-audit** | Python dependency CVEs | `_python-security.yml` (reusable workflow) |
+| **OSV Scanner** | Multi-ecosystem lockfile CVEs | `_osv-scan.yml` (reusable workflow) |
+| **Daily Malicious Code Scan** | Pattern-based threat detection | Copilot agent (per-repo) |
+| **Zizmor** | GitHub Actions security linting | Pre-commit hook |
+
+## Incident Response — Supply-Chain Attacks
+
+### Detection
+
+- GitHub Advisory Database alerts (via Renovate `vulnerabilityAlerts`)
+- CodeQL and OSV Scanner findings in CI
+- Daily malicious code scan alerts
+- Community notification (mailing lists, social media, CVE databases)
+
+### Immediate Response (within 1 hour)
+
+1. Identify all repos consuming the compromised package
+2. Check Renovate PR history — was a compromised version offered or merged?
+3. Check `flake.lock` timestamps — did a manual update pull it?
+4. Check `uv tool list` — is the compromised version installed locally?
+
+### Containment
+
+- Add version constraint to block compromised versions (e.g., `!=bad.version`)
+- If Nix flake input: pin to known-good commit hash temporarily
+- If `uv tool install`: downgrade to last known-good version with `==`
+- Clear local caches: `uv cache clean <package>`
+
+### Verification
+
+- Run `nix flake metadata` to confirm pinned revisions
+- Check `uv tool list` for installed versions
+- Audit CI logs for the affected time window
+- Check for IOCs specific to the attack
+
+### Recovery
+
+- Update to patched version when available
+- Remove temporary pins and constraints
+- Document incident in a GitHub Discussion for future reference
+
+## Accepted Risks
+
+### nix-devenv uses `nixpkgs-unstable`
+
+Intentional. Dev shells need latest tool versions (terraform, ansible, kubectl).
+nix-devenv is never consumed by nix-darwin at build time — it provides independent
+`nix develop` entry points outside the system build graph.
+
+### Nix Flake Alignment (`follows` Pattern)
+
+nix-darwin uses `inputs.nixpkgs.follows` to force companion repos (nix-ai,
+nix-home) to use the same nixpkgs at build time, regardless of their own
+`flake.lock`. This means flake.lock drift between repos is cosmetic for the
+system build but matters for standalone development and CI.


### PR DESCRIPTION
## Summary

- Add org-wide `SECURITY.md` with supply-chain security policy, dependency trust tiers, incident response procedures, and accepted risks documentation
- Add `_python-security.yml` reusable workflow for pip-audit scanning via `uv export` (no arbitrary install hooks)
- Add `_osv-scan.yml` reusable workflow for Google OSV multi-ecosystem lockfile vulnerability scanning

Closes #63

Related: nix-darwin #925, nix-ai #341 (consumer ci-gate wiring, out of scope for this PR)

## Changes

- **SECURITY.md**: Org-wide security policy covering vulnerability reporting, dependency trust tiers (Always Trusted / Trusted Wait / Trusted Nix / Default), version pinning strategies, dependency update vectors, security scanning tool inventory, and incident response playbook
- **_python-security.yml**: Reusable `workflow_call` workflow — uses `uv export --locked` to generate requirements, then `uvx pip-audit` to scan for CVEs without running install hooks. Includes `concurrency` group and env-var-based input passing to prevent script injection
- **_osv-scan.yml**: Reusable `workflow_call` workflow — runs `google/osv-scanner-action@v2` recursively. Includes `concurrency` group matching repo convention
- **.cspell.json**: Added dictionary entries for zizmor, endgroup, and lockfiles

## Test plan

- [x] SECURITY.md renders correctly and will be inherited by repos without their own
- [x] Workflow YAML passes `check-yaml` pre-commit hook
- [x] cspell, markdownlint, markdown-link-check all pass
- [x] CodeQL passes with no open alerts
- [x] Workflows are callable from consumer ci-gates (wiring in separate PRs)
