### PR TITLE
fix(ci): remove bot approval causing stuck release-please PRs

### DIFF
--- a/.github/workflows/_release-please.yml
+++ b/.github/workflows/_release-please.yml
@@ -91,7 +91,8 @@ jobs:
 
       # Bot approval (github.token) was triggering premature auto-merge evaluation
       # before CI checks registered, causing auto-merge to get stuck with rulesets
-      # (github/community#162623). Removed — required_approving_review_count is 0.
+      # (github/community#162623). Removed; repos requiring approvals will leave
+      # auto-merge pending until the required human reviews are submitted.
       - name: Enable auto-merge for release PR
         if: "!cancelled() && steps.find-pr.outputs.number != ''"
         env:

--- a/.github/workflows/_release-please.yml
+++ b/.github/workflows/_release-please.yml
@@ -15,7 +15,6 @@
 #         GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
 #
 # Org/repo prerequisites:
-#   "Allow GitHub Actions to create and approve pull requests" must be enabled
 #   Calling repos must grant `contents: write` and `pull-requests: write` in the caller job permissions
 #
 # Repo files:
@@ -90,16 +89,12 @@ jobs:
           PR_NUMBER=$(gh pr list --head "release-please--branches--${BASE_BRANCH}" --json number --jq '.[0].number // empty')
           echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
 
+      # Bot approval (github.token) was triggering premature auto-merge evaluation
+      # before CI checks registered, causing auto-merge to get stuck with rulesets
+      # (github/community#162623). Removed — required_approving_review_count is 0.
       - name: Enable auto-merge for release PR
         if: "!cancelled() && steps.find-pr.outputs.number != ''"
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ steps.find-pr.outputs.number }}
         run: gh pr merge "$PR_NUMBER" --auto --squash
-
-      - name: Approve release PR
-        if: "!cancelled() && steps.find-pr.outputs.number != ''"
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ steps.find-pr.outputs.number }}
-        run: gh pr review "$PR_NUMBER" --approve


### PR DESCRIPTION
## Summary

- Remove the "Approve release PR" step from `_release-please.yml` that was causing auto-merge to get stuck intermittently

## Changes

- `.github/workflows/_release-please.yml`: Removed the "Approve release PR" step (removed 8 lines total, added 4 lines of explanatory comments)

## Root Cause

The bot approval (via `github.token`) triggers auto-merge to evaluate merge conditions **before CI checks have registered**. Due to a known GitHub bug with rulesets ([github/community#162623](https://github.com/orgs/community/discussions/162623)), auto-merge never re-evaluates when checks later pass — leaving release-please PRs stuck indefinitely despite `mergeStateStatus: CLEAN`.

**Confirmed by experiment:** Manually approving stuck PRs (ansible-proxmox-apps#144, terraform-proxmox#209) as a human triggered auto-merge immediately — because checks had already passed by then.

**Why intermittent:** When the bot approval lands *after* checks complete (rare timing), auto-merge evaluates and merges. When it lands *before* (common), it gets stuck.

## Fix

Remove the approve step. `required_approving_review_count` is `0` on all repos, so the approval serves no purpose. Without it, auto-merge won't do a premature evaluation — it will only evaluate when checks complete (the natural `check_suite` trigger).

## Fallback

If this doesn't fully resolve it, the next step is replacing `--auto` with direct merge:
```yaml
run: gh pr checks "$PR_NUMBER" --watch && gh pr merge "$PR_NUMBER" --squash
```

## Test plan

- [ ] Push fix to main
- [ ] Make a `fix:` commit to any repo to trigger release-please
- [ ] Verify release-please PR auto-merges within ~2 minutes without getting stuck


🤖 Generated with [Claude Code](https://claude.com/claude-code)
