### PR TITLE
fix(deps): add vulnerabilityAlerts to shared Renovate preset

### DIFF
--- a/renovate-presets.json
+++ b/renovate-presets.json
@@ -2,6 +2,14 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "description": "JacobPEvans org-wide Renovate preset",
   "platformAutomerge": true,
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "labels": ["security"],
+    "automerge": true,
+    "automergeType": "pr",
+    "automergeStrategy": "squash",
+    "minimumReleaseAge": "0 days"
+  },
   "customManagers": [
     {
       "description": "Nix version pins annotated with renovate comments",

--- a/renovate-presets.json
+++ b/renovate-presets.json
@@ -4,7 +4,7 @@
   "platformAutomerge": true,
   "vulnerabilityAlerts": {
     "enabled": true,
-    "labels": ["security"],
+    "labels": ["type:security"],
     "automerge": true,
     "automergeType": "pr",
     "automergeStrategy": "squash",


### PR DESCRIPTION
## Summary

- Add `vulnerabilityAlerts` top-level block to the shared Renovate preset (`renovate-presets.json`)
- Enables Renovate to handle security vulnerability PRs org-wide, replacing Dependabot automated security fixes
- All repos inherit this automatically via `local>JacobPEvans/.github:renovate-presets`

## Changes

- `vulnerabilityAlerts.enabled: true` — activates Renovate vulnerability handling
- `labels: ["type:security"]` — uses the org's canonical label from `.github/labels.yml`
- `automerge: true` with `automergeStrategy: "squash"` — consistent with existing automerge rules
- `minimumReleaseAge: "0 days"` — no soak period for security fixes (the vulnerability alert itself provides vetting)
- Placed as top-level key per Renovate docs (`vulnerabilityAlerts` is not a `packageRules` option)
- Loosened OSV scanner pin from `v2.3.5` to `v2` (major version tag)
- Removed `google/**` from trusted GitHub Actions list (use standard vetting instead)

## Design Decisions

- **0-day release age** intentionally differs from nix-darwin's 3-day soak — org-wide security fixes should land fast
- **Squash strategy** matches every other automerge rule in this preset
- **`type:security` label** aligns with `labels.yml` convention (not bare `security`)

## Next Steps

After merge, disable Dependabot automated-security-fixes for repos where Renovate is active to avoid duplicate security PRs.

Related: #127, #128

## Test Plan

- [x] JSON validated locally
- [ ] Confirm Renovate picks up the new config on next scheduled run
- [ ] Verify security vulnerability PRs get the `type:security` label and auto-merge
