### PR TITLE
fix(ci): pin osv-scanner-action to SHA after v2 tag removal

### DIFF
--- a/.github/workflows/_osv-scan.yml
+++ b/.github/workflows/_osv-scan.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Run OSV Scanner
-        uses: google/osv-scanner-action/osv-scanner-action@v2
+        uses: google/osv-scanner-action/osv-scanner-action@c5996e0193a3df57d695c1b8a1dec2a4c62e8730 # v2.3.3
         with:
           scan-args: |-
             --recursive


### PR DESCRIPTION
## Summary

- Pin `google/osv-scanner-action/osv-scanner-action` from `@v2` to `@c5996e0193a3df57d695c1b8a1dec2a4c62e8730` (v2.3.3)
- Google deleted the `v2` major version tag, breaking all workflows that referenced it
- Uses SHA pin per our policy for external (non-trusted-org) actions

## Changes

- `.github/workflows/_osv-scan.yml`: Replace `@v2` tag reference with SHA commit pin `@c5996e0193a3df57d695c1b8a1dec2a4c62e8730` and add `# v2.3.3` version comment for readability

Related: #128

## Test plan

- [ ] Verify a downstream repo's CI gate that calls `_osv-scan.yml` resolves the action successfully
- [ ] Confirm the SHA matches the v2.3.3 release tag on google/osv-scanner-action
