### PR TITLE
fix(ci): pin osv-scanner-action to valid v2.3.5 SHA

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -41,7 +41,13 @@
     "zizmor",
     "Zizmor",
     "endgroup",
-    "lockfiles"
+    "lockfiles",
+    "pygments",
+    "GHSA",
+    "wwwm",
+    "AdlLexer",
+    "ReDoS",
+    "transitive"
   ],
   "ignorePaths": [
     ".git",

--- a/.github/workflows/_osv-scan.yml
+++ b/.github/workflows/_osv-scan.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Run OSV Scanner
-        uses: google/osv-scanner-action/osv-scanner-action@v2
+        uses: google/osv-scanner-action/osv-scanner-action@c51854704019a247608d928f370c98740469d4b5 # v2.3.5
         with:
           scan-args: |-
             --recursive

--- a/.github/workflows/_python-security.yml
+++ b/.github/workflows/_python-security.yml
@@ -37,6 +37,11 @@ jobs:
             echo "::group::Scanning $dir"
             cd "$GITHUB_WORKSPACE/$dir"
             uv export --format requirements-txt --output-file requirements.txt --locked
-            uvx pip-audit --progress-spinner=off --desc -r requirements.txt
+            # GHSA-5239-wwwm-4pmq (CVE-2026-4539): ReDoS in pygments AdlLexer — transitive dep via
+            # rich and pytest; only triggered when parsing ADL files (not done here); no fix yet.
+            # Remove this flag once pygments releases a patched version (tracked in nix-ai#355).
+            uvx pip-audit --progress-spinner=off --desc \
+              --ignore-vuln GHSA-5239-wwwm-4pmq \
+              -r requirements.txt
             echo "::endgroup::"
           done


### PR DESCRIPTION
## Summary

Fixes two CI failures that were breaking all PRs across all repos using these shared workflows.

### Fix 1: OSV Scanner action version

- `google/osv-scanner-action@v2` fails to resolve — `v2` is not a published tag in that repo, only versioned tags like `v2.3.5` exist
- Pin to the SHA of `v2.3.5` per the untrusted-action pinning policy (google is not in the trusted org list)

### Fix 2: pip-audit pygments CVE exception

- `CVE-2026-4539` (GHSA-5239-wwwm-4pmq): ReDoS in `pygments` AdlLexer — transitive dependency via `rich` and `pytest`
- No patched version of pygments exists yet (latest is 2.19.2)
- Vulnerability only triggers when parsing ADL files — none of these repos process ADL files
- Uses `--ignore-vuln`, pip-audit's documented mechanism for known unfixable CVEs
- Tracked for removal in nix-ai#355 once a patched pygments is released

## Impact

Both failures were causing every CI Gate run across all repos to fail. This fix unblocks all affected PRs.

## Test Plan

- [ ] CI passes (OSV Scan resolves the action, pip-audit passes with the exemption)
- [ ] Renovate will keep the OSV scanner SHA up to date
- [ ] nix-ai#355 tracks pygments upgrade when a fix lands