### PR TITLE
fix(ci): add pip-audit pygments CVE exception

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -41,7 +41,13 @@
     "zizmor",
     "Zizmor",
     "endgroup",
-    "lockfiles"
+    "lockfiles",
+    "pygments",
+    "GHSA",
+    "wwwm",
+    "AdlLexer",
+    "ReDoS",
+    "transitive"
   ],
   "ignorePaths": [
     ".git",

--- a/.github/workflows/_python-security.yml
+++ b/.github/workflows/_python-security.yml
@@ -37,6 +37,11 @@ jobs:
             echo "::group::Scanning $dir"
             cd "$GITHUB_WORKSPACE/$dir"
             uv export --format requirements-txt --output-file requirements.txt --locked
-            uvx pip-audit --progress-spinner=off --desc -r requirements.txt
+            # GHSA-5239-wwwm-4pmq (CVE-2026-4539): ReDoS in pygments AdlLexer — transitive dep via
+            # rich and pytest; only triggered when parsing ADL files (not done here); no fix yet.
+            # Remove this flag once pygments releases a patched version (tracked in nix-ai#355).
+            uvx pip-audit --progress-spinner=off --desc \
+              --ignore-vuln GHSA-5239-wwwm-4pmq \
+              -r requirements.txt
             echo "::endgroup::"
           done


### PR DESCRIPTION
## Summary

- Add `--ignore-vuln GHSA-5239-wwwm-4pmq` to pip-audit to unblock CI across all repos consuming this reusable workflow
- GHSA-5239-wwwm-4pmq (CVE-2026-4539): ReDoS in pygments `AdlLexer` — transitive dep via `rich`/`pytest`, no patched version exists, only triggers on ADL files (not used here)
- Add cspell dictionary entries for CVE-related terms in the inline comment

## Changes

- **`_python-security.yml`**: Add `--ignore-vuln GHSA-5239-wwwm-4pmq` with inline rationale comment
- **`.cspell.json`**: Add words from CVE comment (pygments, GHSA, wwwm, AdlLexer, ReDoS, transitive)

## Test plan

- [x] CI passes — pip-audit completes without failure
- [x] CodeQL clean — no new code-scanning alerts

Related: JacobPEvans/nix-ai#355 (tracking removal once patched pygments releases)
