### PR TITLE
fix: disable MD012 for CHANGELOG.md in shared markdownlint config

### DIFF
--- a/configs/.markdownlint-cli2.yaml
+++ b/configs/.markdownlint-cli2.yaml
@@ -20,3 +20,5 @@ overrides:
     config:
       # release-please generates long lines with PR links
       MD013: false
+      # release-please generates double blank lines between version header and section
+      MD012: false


### PR DESCRIPTION
## Summary
- Add `MD012: false` to the CHANGELOG.md override in shared markdownlint config
- release-please generates double blank lines between version headers and section headers ([googleapis/release-please#2085](https://github.com/googleapis/release-please/issues/2085), closed won't-fix)
- Follows the same pattern as the existing MD013 override for CHANGELOG.md

## Test plan
- [x] Shared config has the override
- [ ] Next release-please PR in any repo passes markdownlint

🤖 Generated with [Claude Code](https://claude.com/claude-code)