### PR TITLE
fix(ci): exclude project package from pip-audit export

### DIFF
--- a/.github/workflows/_python-security.yml
+++ b/.github/workflows/_python-security.yml
@@ -36,7 +36,7 @@ jobs:
           for dir in $PYTHON_DIRS; do
             echo "::group::Scanning $dir"
             cd "$GITHUB_WORKSPACE/$dir"
-            uv export --format requirements-txt --output-file requirements.txt --locked
+            uv export --format requirements-txt --output-file requirements.txt --locked --no-emit-project
             # GHSA-5239-wwwm-4pmq (CVE-2026-4539): ReDoS in pygments AdlLexer — transitive dep via
             # rich and pytest; only triggered when parsing ADL files (not done here); no fix yet.
             # Remove this flag once pygments releases a patched version (tracked in nix-ai#355).

--- a/.github/workflows/_python-security.yml
+++ b/.github/workflows/_python-security.yml
@@ -36,6 +36,9 @@ jobs:
           for dir in $PYTHON_DIRS; do
             echo "::group::Scanning $dir"
             cd "$GITHUB_WORKSPACE/$dir"
+            # --no-emit-project avoids exporting the local project as an editable requirement when
+            # hashes are present, which would cause pip / pip-audit to fail with
+            # "editable requirement cannot be installed when requiring hashes".
             uv export --format requirements-txt --output-file requirements.txt --locked --no-emit-project
             # GHSA-5239-wwwm-4pmq (CVE-2026-4539): ReDoS in pygments AdlLexer — transitive dep via
             # rich and pytest; only triggered when parsing ADL files (not done here); no fix yet.


### PR DESCRIPTION
## Summary
- Add `--no-emit-project` to `uv export` in `_python-security.yml`
- Fixes pip-audit failure: "editable requirement cannot be installed when requiring hashes"
- Affects any repo where `pyproject.toml` defines the project as a package (e.g., nix-ai/orchestrator)

## Test plan
- [x] Verified `uv export --no-emit-project` excludes the local package from requirements.txt
- [ ] Re-run nix-ai CI after merge to confirm pip-audit passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)