### PR TITLE
fix(ci): add --no-emit-project to uv export in pip-audit

### DIFF
--- a/.github/workflows/_python-security.yml
+++ b/.github/workflows/_python-security.yml
@@ -36,7 +36,7 @@ jobs:
           for dir in $PYTHON_DIRS; do
             echo "::group::Scanning $dir"
             cd "$GITHUB_WORKSPACE/$dir"
-            uv export --format requirements-txt --output-file requirements.txt --locked
+            uv export --format requirements-txt --output-file requirements.txt --no-emit-project --locked
             # GHSA-5239-wwwm-4pmq (CVE-2026-4539): ReDoS in pygments AdlLexer — transitive dep via
             # rich and pytest; only triggered when parsing ADL files (not done here); no fix yet.
             # Remove this flag once pygments releases a patched version (tracked in nix-ai#355).


### PR DESCRIPTION
## Summary

- Add `--no-emit-project` flag to `uv export` in `_python-security.yml`
- Fixes pip-audit failures in repos using uv workspaces where `-e .` (editable self-reference) is incompatible with `--require-hashes`

## Test plan

- [ ] nix-ai Python Security check passes after this merges


🤖 Generated with [Claude Code](https://claude.com/claude-code)