### PR TITLE
fix(ci): pass osv-scanner.toml config when present

### DIFF
--- a/.github/workflows/_osv-scan.yml
+++ b/.github/workflows/_osv-scan.yml
@@ -22,9 +22,19 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Check for config file
+        id: config
+        run: |
+          if [ -f osv-scanner.toml ]; then
+            echo "args=--config=osv-scanner.toml" >> "$GITHUB_OUTPUT"
+          else
+            echo "args=" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Run OSV Scanner
         uses: google/osv-scanner-action/osv-scanner-action@v2.3.5
         with:
           scan-args: |-
+            ${{ steps.config.outputs.args }}
             --recursive
             .


### PR DESCRIPTION
## Summary

- Add config file detection step to `_osv-scan.yml` so repos with `osv-scanner.toml` can suppress known unfixable advisories
- When `osv-scanner.toml` exists in the calling repo, passes `--config=osv-scanner.toml` to the scanner
- Backwards compatible: repos without the config file are unaffected (scanner runs with default behavior)

## Changes

- **`.github/workflows/_osv-scan.yml`**: Added a `Check for config file` step that detects `osv-scanner.toml` and sets a step output. The output is interpolated into `scan-args` for the OSV scanner action.

## Test plan

- [ ] Verify nix-ai OSV Scan passes after this lands (with nix-ai adding its own `osv-scanner.toml`)
- [ ] Verify repos without `osv-scanner.toml` continue to scan normally (empty string in scan-args is harmless whitespace)
