### PR TITLE
fix(deps): add twice-weekly Renovate schedule for wrapper packages

### DIFF
--- a/renovate-presets.json
+++ b/renovate-presets.json
@@ -10,6 +10,7 @@
     "automergeStrategy": "squash",
     "minimumReleaseAge": "0 days"
   },
+  "timezone": "America/Chicago",
   "lockFileMaintenance": {
     "enabled": true,
     "schedule": ["before 7am on Monday", "before 7am on Thursday"]
@@ -144,7 +145,7 @@
       "minimumReleaseAge": "3 days"
     },
     {
-      "description": "Twice-weekly schedule for custom regex managers (bunx/uvx/uv wrappers)",
+      "description": "Twice-weekly schedule for all custom regex managers",
       "matchManagers": ["custom.regex"],
       "schedule": ["after 7am on Monday", "after 7am on Thursday"]
     },

--- a/renovate-presets.json
+++ b/renovate-presets.json
@@ -10,6 +10,10 @@
     "automergeStrategy": "squash",
     "minimumReleaseAge": "0 days"
   },
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 7am on Monday", "before 7am on Thursday"]
+  },
   "customManagers": [
     {
       "description": "Nix version pins annotated with renovate comments",
@@ -138,6 +142,16 @@
       "automergeType": "pr",
       "automergeStrategy": "squash",
       "minimumReleaseAge": "3 days"
+    },
+    {
+      "description": "Twice-weekly schedule for custom regex managers (bunx/uvx/uv wrappers)",
+      "matchManagers": ["custom.regex"],
+      "schedule": ["after 7am on Monday", "after 7am on Thursday"]
+    },
+    {
+      "description": "Twice-weekly schedule for pep621 managed packages",
+      "matchManagers": ["pep621"],
+      "schedule": ["after 7am on Monday", "after 7am on Thursday"]
     }
   ]
 }


### PR DESCRIPTION
# PR #147: Twice-Weekly Renovate Schedule for Wrapper Packages

## Summary

- Add twice-weekly schedule (Mon + Thu) for `custom.regex` and `pep621` managers in the shared Renovate preset
- Enable `lockFileMaintenance` with twice-weekly schedule
- Add explicit timezone (America/Chicago) for predictable schedule evaluation
- All repos inheriting this preset benefit automatically

## Why

Weekly Monday-only schedule + 3-day release age soak = up to 10 days max staleness for PyPI/npm
wrapper packages. This was discovered when a Python wrapper package was at 1.6.0 locally while
1.8.0 was available on PyPI. Adding Thursday reduces max staleness to ~6.5 days.

## Changes

- renovate-presets.json: Add `timezone`, `lockFileMaintenance`, and two schedule packageRules

## Test plan

- [ ] Verify Renovate validates the updated preset without errors (check Dependency Dashboard)
- [ ] Confirm Thursday schedule entries appear in downstream repo dashboards
- [ ] Lock file maintenance PRs should appear on both Monday and Thursday

🤖 Generated with [Claude Code](https://claude.com/claude-code)
