### PR TITLE
fix(ci): remove stale vulnerability ignores — all CVEs now fixed upstream

### DIFF
--- a/.github/workflows/_python-security.yml
+++ b/.github/workflows/_python-security.yml
@@ -40,11 +40,6 @@ jobs:
             # hashes are present, which would cause pip / pip-audit to fail with
             # "editable requirement cannot be installed when requiring hashes".
             uv export --format requirements-txt --output-file requirements.txt --locked --no-emit-project
-            # GHSA-5239-wwwm-4pmq (CVE-2026-4539): ReDoS in pygments AdlLexer — transitive dep via
-            # rich and pytest; only triggered when parsing ADL files (not done here); no fix yet.
-            # Remove this flag once pygments releases a patched version (tracked in nix-ai#355).
-            uvx pip-audit --progress-spinner=off --desc \
-              --ignore-vuln GHSA-5239-wwwm-4pmq \
-              -r requirements.txt
+            uvx pip-audit --progress-spinner=off --desc -r requirements.txt
             echo "::endgroup::"
           done

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -6,29 +6,3 @@
 # Remove entries promptly when upgrades land.
 #
 # Repos can override with a local osv-scanner.toml (takes precedence).
-
-# pygments 2.19.2 — Low severity (3.3), ReDoS in AdlLexer
-# No patched version available upstream
-[[IgnoredVulns]]
-id = "GHSA-5239-wwwm-4pmq"
-reason = "pygments 2.19.2 is the latest version; no fix available upstream"
-
-# nltk 3.9.3 — High severity (7.5), no patched version for this CVE
-[[IgnoredVulns]]
-id = "GHSA-jm6w-m3j8-898g"
-reason = "nltk 3.9.3 has no fix for this CVE"
-
-# nltk 3.9.3 — Medium severity (5.1), no patched version available
-[[IgnoredVulns]]
-id = "GHSA-rf74-v2fm-23pw"
-reason = "nltk 3.9.3 has no fix available upstream"
-
-# nltk 3.9.3 — Medium severity (6.1), fix available in 3.9.4
-[[IgnoredVulns]]
-id = "GHSA-gfwx-w7gr-fvh7"
-reason = "nltk upgrade to 3.9.4 pending Renovate PR"
-
-# requests 2.32.5 — Medium severity (4.4), fix available in 2.33.0
-[[IgnoredVulns]]
-id = "GHSA-gc5v-m9x4-r6x2"
-reason = "requests upgrade to 2.33.0 pending Renovate PR"


### PR DESCRIPTION
## Summary

- **pygments** 2.20.0 (released 2026-03-29) fixes CVE-2026-4539 (GHSA-5239-wwwm-4pmq) — removes the `--ignore-vuln` flag from the `_python-security.yml` pip-audit command and the 3-line comment block above it
- **nltk** 3.9.4 fixes GHSA-jm6w-m3j8-898g, GHSA-rf74-v2fm-23pw, and GHSA-gfwx-w7gr-fvh7 — already upgraded, advisory DB entries are now stale
- **requests** 2.33.0 fixes GHSA-gc5v-m9x4-r6x2 — already upgraded
- `osv-scanner.toml` now contains only the header comment block with no active `[[IgnoredVulns]]` entries

## Files Changed

- `.github/workflows/_python-security.yml` — remove pygments CVE ignore flag and associated comments; `uvx pip-audit` command is now clean
- `osv-scanner.toml` — remove all 5 stale `[[IgnoredVulns]]` entries; keep file with header comment only (required for `_osv-scan.yml` fallback mechanism)

## Test plan

- [ ] Verify CI passes on this PR (pip-audit and OSV scanner run clean against current dependency versions)
- [ ] Confirm no new CVE alerts fire (all addressed packages are at patched versions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)