### PR TITLE
fix(renovate): centralize pep621 automerge for Python packages

### DIFF
--- a/renovate-presets.json
+++ b/renovate-presets.json
@@ -150,8 +150,13 @@
       "schedule": ["after 7am on Monday", "after 7am on Thursday"]
     },
     {
-      "description": "Twice-weekly schedule for pep621 managed packages",
+      "description": "Auto-merge pep621 Python packages (minor/patch, 3-day stabilization)",
       "matchManagers": ["pep621"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true,
+      "automergeType": "pr",
+      "automergeStrategy": "squash",
+      "minimumReleaseAge": "3 days",
       "schedule": ["after 7am on Monday", "after 7am on Thursday"]
     }
   ]


### PR DESCRIPTION
## Summary

- Adds org-wide automerge rule for `pep621`-managed Python packages (minor/patch only)
- Merges the existing pep621 schedule rule with automerge fields (3-day stabilization, squash strategy)
- All repos extending this preset with `pyproject.toml` files now get automated Python dependency updates

## Motivation

PR JacobPEvans/nix-ai#370 added per-repo automerge overrides for pep621 packages. This belongs in the
shared preset alongside the existing trust rules for GitHub Actions, Terraform, Nix flakes, and PyPI/HuggingFace.

## Immediate beneficiaries

- **nix-ai** — mlx-server + orchestrator pyproject.toml dependencies
- **python-template** — pytest, ruff, mypy, bandit dev dependencies

## Test plan

- [ ] Renovate dashboard shows pep621 automerge enabled for nix-ai and python-template
- [ ] Major version updates remain blocked (existing rule)
- [ ] Verify 3-day minimumReleaseAge applies

🤖 Generated with [Claude Code](https://claude.com/claude-code)