### PR TITLE
fix: enable pinGitHubActionDigests and add trusted orgs

### DIFF
--- a/renovate-presets.json
+++ b/renovate-presets.json
@@ -4,6 +4,7 @@
   "platformAutomerge": true,
   "automergeType": "pr",
   "automergeStrategy": "squash",
+  "pinGitHubActionDigests": true,
   "minimumReleaseAge": "3 days",
   "timezone": "America/Chicago",
   "vulnerabilityAlerts": {
@@ -25,6 +26,14 @@
       "fileMatch": ["\\.nix$"],
       "matchStrings": [
         "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)\\r?\\n\\s*\\S+\\s*=\\s*\"(?<currentValue>[^\"]+)\";"
+      ]
+    },
+    {
+      "description": "npx version pins in GitHub Actions workflows annotated with renovate comments",
+      "customType": "regex",
+      "fileMatch": ["\\.github/workflows/.*\\.ya?ml$"],
+      "matchStrings": [
+        "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)[\\r\\n]+.*npx\\s+(?:--yes\\s+|-y\\s+)?\\S+@(?<currentValue>[^\\s\"']+)"
       ]
     }
   ],
@@ -49,6 +58,7 @@
         "actions/**",
         "ansible/**",
         "anthropics/**",
+        "aquasecurity/**",
         "astral-sh/**",
         "aws-actions/**",
         "aws-ia/**",
@@ -72,6 +82,7 @@
         "huggingface/**",
         "kubernetes/**",
         "kubernetes-sigs/**",
+        "lycheeverse/**",
         "microsoft/**",
         "nix-community/**",
         "nix-darwin/**",
@@ -82,6 +93,7 @@
         "open-telemetry/**",
         "opentofu/**",
         "ossf/**",
+        "oven-sh/**",
         "oxalica/**",
         "peter-evans/**",
         "pre-commit/**",
@@ -92,10 +104,13 @@
         "semgrep/**",
         "sigstore/**",
         "softprops/**",
+        "streetsidesoftware/**",
+        "terraform-linters/**",
         "wakatime/**",
         "https://github.com/actions/**",
         "https://github.com/ansible/**",
         "https://github.com/anthropics/**",
+        "https://github.com/aquasecurity/**",
         "https://github.com/astral-sh/**",
         "https://github.com/aws-actions/**",
         "https://github.com/aws-ia/**",
@@ -119,6 +134,7 @@
         "https://github.com/huggingface/**",
         "https://github.com/kubernetes/**",
         "https://github.com/kubernetes-sigs/**",
+        "https://github.com/lycheeverse/**",
         "https://github.com/microsoft/**",
         "https://github.com/nix-community/**",
         "https://github.com/nix-darwin/**",
@@ -129,6 +145,7 @@
         "https://github.com/open-telemetry/**",
         "https://github.com/opentofu/**",
         "https://github.com/ossf/**",
+        "https://github.com/oven-sh/**",
         "https://github.com/oxalica/**",
         "https://github.com/peter-evans/**",
         "https://github.com/pre-commit/**",
@@ -139,6 +156,8 @@
         "https://github.com/semgrep/**",
         "https://github.com/sigstore/**",
         "https://github.com/softprops/**",
+        "https://github.com/streetsidesoftware/**",
+        "https://github.com/terraform-linters/**",
         "https://github.com/wakatime/**"
       ],
       "automerge": true,

--- a/renovate-presets.json
+++ b/renovate-presets.json
@@ -33,7 +33,7 @@
       "customType": "regex",
       "fileMatch": ["\\.github/workflows/.*\\.ya?ml$"],
       "matchStrings": [
-        "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)[\\r\\n]+.*npx\\s+(?:--yes\\s+|-y\\s+)?\\S+@(?<currentValue>[^\\s\"']+)"
+        "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)[\\r\\n]+[\\s\\S]*?\\bnpx\\b\\s+(?:--yes\\s+|-y\\s+)?\\S+@(?<currentValue>[^\\s\"']+)"
       ]
     }
   ],


### PR DESCRIPTION
## Summary

- **Enable `pinGitHubActionDigests`**: Renovate will now automatically convert all GitHub Actions tag references to SHA-pinned digests org-wide, preventing tag-poisoning attacks (addresses CVE-2026-33634)
- **Add 5 new trusted orgs**: `aquasecurity`, `terraform-linters`, `lycheeverse`, `streetsidesoftware`, `oven-sh` — enables faster auto-merge for security/lint tooling updates from these verified publishers
- **Add npx regex manager**: Custom regex manager detects and updates `npx` version pins in GitHub Actions workflow YAML files annotated with renovate comments

## Test plan

- [ ] Verify Renovate picks up the new `pinGitHubActionDigests` setting and begins opening SHA-pin PRs across org repos
- [ ] Confirm new trusted orgs appear in Renovate's auto-merge scope (check next dependency update PRs from these orgs)
- [ ] Validate npx regex manager matches annotated `npx` calls in existing workflow files (dry-run Renovate locally or wait for next scheduled run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)