### PR TITLE
fix: broaden commit signing language from GPG-only to all methods

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/breaking.md
+++ b/.github/PULL_REQUEST_TEMPLATE/breaking.md
@@ -91,7 +91,7 @@ See [LABELS.md](../docs/LABELS.md) for label definitions.
 <!-- Please confirm the following before submitting your pull request -->
 
 - [ ] PR title follows conventional commits format: `breaking(scope): description`
-- [ ] All commits are GPG signed
+- [ ] All commits are signed
 - [ ] No merge commits (rebased if needed)
 - [ ] Migration path is clear and documented
 - [ ] All tests passing

--- a/.github/PULL_REQUEST_TEMPLATE/bug.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bug.md
@@ -67,7 +67,7 @@ See [LABELS.md](../docs/LABELS.md) for label definitions.
 
 - [ ] PR title follows conventional commits format: `fix(scope): description`
 - [ ] Commits follow conventional commits specification
-- [ ] All commits are GPG signed
+- [ ] All commits are signed
 - [ ] No merge commits (rebased if needed)
 - [ ] PR is focused on this single bug fix
 - [ ] Self-review completed

--- a/.github/PULL_REQUEST_TEMPLATE/docs.md
+++ b/.github/PULL_REQUEST_TEMPLATE/docs.md
@@ -62,7 +62,7 @@ See [LABELS.md](../docs/LABELS.md) for label definitions.
 
 - [ ] Follows existing documentation structure
 - [ ] PR title follows conventional commits format: `docs(scope): description`
-- [ ] All commits are GPG signed
+- [ ] All commits are signed
 - [ ] No merge commits (rebased if needed)
 - [ ] Markdown linting passed
 - [ ] Self-review completed

--- a/.github/PULL_REQUEST_TEMPLATE/feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature.md
@@ -84,7 +84,7 @@ See [LABELS.md](../docs/LABELS.md) for label definitions.
 
 - [ ] PR title follows conventional commits format: `feat(scope): description`
 - [ ] Commits follow conventional commits specification
-- [ ] All commits are GPG signed
+- [ ] All commits are signed
 - [ ] No merge commits (rebased if needed)
 - [ ] Feature is complete and ready for merge
 - [ ] Breaking changes documented (if any)

--- a/.github/PULL_REQUEST_TEMPLATE/performance.md
+++ b/.github/PULL_REQUEST_TEMPLATE/performance.md
@@ -83,7 +83,7 @@ See [LABELS.md](../docs/LABELS.md) for label definitions.
 
 - [ ] PR title follows conventional commits format: `perf(scope): description`
 - [ ] Commits follow conventional commits specification
-- [ ] All commits are GPG signed
+- [ ] All commits are signed
 - [ ] No merge commits (rebased if needed)
 - [ ] Benchmarks prove improvement
 - [ ] All tests passing

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -81,7 +81,7 @@ See [LABELS.md](../docs/LABELS.md) for label definitions.
 
 - [ ] PR title follows conventional commits format: `type(scope): description`
 - [ ] Commits follow conventional commits specification
-- [ ] All commits are GPG signed
+- [ ] All commits are signed
 - [ ] No merge commits (rebased if needed)
 - [ ] PR is focused on a single concern
 - [ ] Self-review completed

--- a/.github/PULL_REQUEST_TEMPLATE/refactor.md
+++ b/.github/PULL_REQUEST_TEMPLATE/refactor.md
@@ -75,7 +75,7 @@ See [LABELS.md](../docs/LABELS.md) for label definitions.
 
 - [ ] PR title follows conventional commits format: `refactor(scope): description`
 - [ ] Commits follow conventional commits specification
-- [ ] All commits are GPG signed
+- [ ] All commits are signed
 - [ ] No merge commits (rebased if needed)
 - [ ] No functional changes (or clearly documented)
 - [ ] All tests passing

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Standardized [pull request templates][pr-templates-docs] that enforce convention
 - Conventional commit format in PR title (`type(scope): description`)
 - Related issue linking
 - Type, priority, and size labels
-- GPG-signed commits
+- Signed commits
 
 **Selecting a template**:
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -45,9 +45,8 @@ The `claude/` and `copilot/` prefixes are reserved for automated branches create
 
 **Commit signing is required** for all contributions. This verifies that commits come from their claimed author.
 
-> **Automated PRs** (Copilot, Renovate, GitHub Actions): Commits are signed automatically via
-> GitHub's native app signing. No setup needed — just assign an issue to Copilot or let Renovate
-> do its thing.
+> **Automated PRs** (Copilot, Renovate, GitHub Actions): In this organization, automated commits
+> are signed via GitHub's native app signing. No setup needed for bot-authored PRs.
 
 ### Human Contributors — Getting Started
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -43,9 +43,13 @@ The `claude/` and `copilot/` prefixes are reserved for automated branches create
 
 ## Signing Your Commits
 
-**Commit signing is required** for all contributions. This verifies that commits actually come from you.
+**Commit signing is required** for all contributions. This verifies that commits come from their claimed author.
 
-### Getting Started with Commit Signing
+> **Automated PRs** (Copilot, Renovate, GitHub Actions): Commits are signed automatically via
+> GitHub's native app signing. No setup needed — just assign an issue to Copilot or let Renovate
+> do its thing.
+
+### Human Contributors — Getting Started
 
 If you've never signed commits before, don't worry—it only takes a few minutes to set up:
 
@@ -169,7 +173,7 @@ Before submitting your PR:
 - [ ] Related issues are linked in the description
 - [ ] Type, priority, and size labels are applied
 - [ ] Commits follow conventional commits specification
-- [ ] All commits are GPG signed
+- [ ] All commits are signed
 - [ ] No merge commits (rebase if needed)
 - [ ] Markdown linting passes
 - [ ] PR is focused on a single concern


### PR DESCRIPTION
## Summary

- Update all 7 PR templates: `All commits are GPG signed` → `All commits are signed`
- Update CONTRIBUTING.md: broaden signing section to acknowledge automated signing (Copilot, Renovate, GitHub Actions)
- Update README.md: `GPG-signed commits` → `Signed commits`

GitHub now supports GPG, SSH, S/MIME, and native app signing. Copilot cloud agent
[started signing commits on 2026-04-03](https://github.blog/changelog/2026-04-03-copilot-cloud-agent-signs-its-commits/).
The old "GPG signed" language was overly specific and excluded valid signing methods.

These are org-wide inherited defaults — changes propagate to all repos without overrides.

Closes JacobPEvans/ai-workflows#126

## Test plan

- [ ] Verify inherited templates render correctly on a repo without overrides
- [ ] Confirm Copilot cloud agent can create signed PRs (test issue: JacobPEvans/ai-workflows#126)


🤖 Generated with [Claude Code](https://claude.com/claude-code)