### PR TITLE
feat(renovate): add npm-in-nix and uv/uvx custom managers to org preset

### DIFF
--- a/renovate-presets.json
+++ b/renovate-presets.json
@@ -29,12 +29,12 @@
       ]
     },
     {
-      "description": "npm packages pinned in Nix string literals (bunx/npx wrappers, MCP server args)",
+      "description": "npm packages pinned in Nix string literals (bunx wrappers, MCP server args)",
       "customType": "regex",
       "fileMatch": ["\\.nix$"],
       "matchStrings": [
         "\"(?<depName>@[a-zA-Z0-9-]+/[a-zA-Z0-9][a-zA-Z0-9._-]*)@(?<currentValue>[\\d][^\\s\"]*)\"",
-        "bunx\\s+--bun\\s+(?<depName>(?:@[^@/]+\\/)?[^@\\s]+)@(?<currentValue>[\\d][^\\s]*)"
+        "bunx\\s+--bun\\s+(?<depName>(?:@[^@/]+\\/)?[^@\\s]+)@(?<currentValue>[\\d][^\\s\"']*)"
       ],
       "datasourceTemplate": "npm"
     },
@@ -45,8 +45,8 @@
       "matchStrings": [
         "uvx\\s+--from\\s+\"(?<depName>[a-zA-Z0-9][a-zA-Z0-9._-]*)(?:\\[[^\\]]+\\])?==(?<currentValue>[\\d][^\\s\"]*)\"",
         "uv\\s+run[^\"]*--with\\s+\"(?<depName>[a-zA-Z0-9][a-zA-Z0-9._-]*)(?:\\[[^\\]]+\\])?==(?<currentValue>[\\d][^\\s\"]*)\"",
-        "\"--from\"\\n\\s+\"(?<depName>[a-zA-Z0-9][a-zA-Z0-9._-]*)(?:\\[[^\\]]+\\])?==(?<currentValue>[\\d][^\\s\"]*)\"",
-        "\"--with\"\\n\\s+\"(?<depName>[a-zA-Z0-9][a-zA-Z0-9._-]*)(?:\\[[^\\]]+\\])?==(?<currentValue>[\\d][^\\s\"]*)\"",
+        "\"--from\"\\r?\\n\\s+\"(?<depName>[a-zA-Z0-9][a-zA-Z0-9._-]*)(?:\\[[^\\]]+\\])?==(?<currentValue>[\\d][^\\s\"]*)\"",
+        "\"--with\"\\r?\\n\\s+\"(?<depName>[a-zA-Z0-9][a-zA-Z0-9._-]*)(?:\\[[^\\]]+\\])?==(?<currentValue>[\\d][^\\s\"]*)\"",
         "\\buv\\S*\\s+tool\\s+install\\s+\"(?<depName>[a-zA-Z0-9][a-zA-Z0-9._-]*)(?:\\[[^\\]]+\\])?==(?<currentValue>[\\d][^\\s\"]*)\""
       ],
       "datasourceTemplate": "pypi"

--- a/renovate-presets.json
+++ b/renovate-presets.json
@@ -4,6 +4,7 @@
   "platformAutomerge": true,
   "automergeType": "pr",
   "automergeStrategy": "squash",
+  "pinGitHubActionDigests": true,
   "minimumReleaseAge": "3 days",
   "timezone": "America/Chicago",
   "vulnerabilityAlerts": {
@@ -25,6 +26,14 @@
       "fileMatch": ["\\.nix$"],
       "matchStrings": [
         "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)\\r?\\n\\s*\\S+\\s*=\\s*\"(?<currentValue>[^\"]+)\";"
+      ]
+    },
+    {
+      "description": "npx version pins in GitHub Actions workflows annotated with renovate comments",
+      "customType": "regex",
+      "fileMatch": ["\\.github/workflows/.*\\.ya?ml$"],
+      "matchStrings": [
+        "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)[\\r\\n]+.*npx\\s+(?:--yes\\s+|-y\\s+)?\\S+@(?<currentValue>[^\\s\"']+)"
       ]
     }
   ],
@@ -49,6 +58,7 @@
         "actions/**",
         "ansible/**",
         "anthropics/**",
+        "aquasecurity/**",
         "astral-sh/**",
         "aws-actions/**",
         "aws-ia/**",
@@ -72,6 +82,7 @@
         "huggingface/**",
         "kubernetes/**",
         "kubernetes-sigs/**",
+        "lycheeverse/**",
         "microsoft/**",
         "nix-community/**",
         "nix-darwin/**",
@@ -82,6 +93,7 @@
         "open-telemetry/**",
         "opentofu/**",
         "ossf/**",
+        "oven-sh/**",
         "oxalica/**",
         "peter-evans/**",
         "pre-commit/**",
@@ -92,10 +104,13 @@
         "semgrep/**",
         "sigstore/**",
         "softprops/**",
+        "streetsidesoftware/**",
+        "terraform-linters/**",
         "wakatime/**",
         "https://github.com/actions/**",
         "https://github.com/ansible/**",
         "https://github.com/anthropics/**",
+        "https://github.com/aquasecurity/**",
         "https://github.com/astral-sh/**",
         "https://github.com/aws-actions/**",
         "https://github.com/aws-ia/**",
@@ -119,6 +134,7 @@
         "https://github.com/huggingface/**",
         "https://github.com/kubernetes/**",
         "https://github.com/kubernetes-sigs/**",
+        "https://github.com/lycheeverse/**",
         "https://github.com/microsoft/**",
         "https://github.com/nix-community/**",
         "https://github.com/nix-darwin/**",
@@ -129,6 +145,7 @@
         "https://github.com/open-telemetry/**",
         "https://github.com/opentofu/**",
         "https://github.com/ossf/**",
+        "https://github.com/oven-sh/**",
         "https://github.com/oxalica/**",
         "https://github.com/peter-evans/**",
         "https://github.com/pre-commit/**",
@@ -139,6 +156,8 @@
         "https://github.com/semgrep/**",
         "https://github.com/sigstore/**",
         "https://github.com/softprops/**",
+        "https://github.com/streetsidesoftware/**",
+        "https://github.com/terraform-linters/**",
         "https://github.com/wakatime/**"
       ],
       "automerge": true,

--- a/renovate-presets.json
+++ b/renovate-presets.json
@@ -33,7 +33,7 @@
       "customType": "regex",
       "fileMatch": ["\\.github/workflows/.*\\.ya?ml$"],
       "matchStrings": [
-        "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)[\\r\\n]+.*npx\\s+(?:--yes\\s+|-y\\s+)?\\S+@(?<currentValue>[^\\s\"']+)"
+        "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)[\\r\\n]+[\\s\\S]*?\\bnpx\\b\\s+(?:--yes\\s+|-y\\s+)?\\S+@(?<currentValue>[^\\s\"']+)"
       ]
     }
   ],

--- a/renovate-presets.json
+++ b/renovate-presets.json
@@ -29,6 +29,29 @@
       ]
     },
     {
+      "description": "npm packages pinned in Nix string literals (bunx/npx wrappers, MCP server args)",
+      "customType": "regex",
+      "fileMatch": ["\\.nix$"],
+      "matchStrings": [
+        "\"(?<depName>@[a-zA-Z0-9-]+/[a-zA-Z0-9][a-zA-Z0-9._-]*)@(?<currentValue>[\\d][^\\s\"]*)\"",
+        "bunx\\s+--bun\\s+(?<depName>(?:@[^@/]+\\/)?[^@\\s]+)@(?<currentValue>[\\d][^\\s]*)"
+      ],
+      "datasourceTemplate": "npm"
+    },
+    {
+      "description": "uv/uvx PyPI packages pinned in Nix modules",
+      "customType": "regex",
+      "fileMatch": ["\\.nix$"],
+      "matchStrings": [
+        "uvx\\s+--from\\s+\"(?<depName>[a-zA-Z0-9][a-zA-Z0-9._-]*)(?:\\[[^\\]]+\\])?==(?<currentValue>[\\d][^\\s\"]*)\"",
+        "uv\\s+run[^\"]*--with\\s+\"(?<depName>[a-zA-Z0-9][a-zA-Z0-9._-]*)(?:\\[[^\\]]+\\])?==(?<currentValue>[\\d][^\\s\"]*)\"",
+        "\"--from\"\\n\\s+\"(?<depName>[a-zA-Z0-9][a-zA-Z0-9._-]*)(?:\\[[^\\]]+\\])?==(?<currentValue>[\\d][^\\s\"]*)\"",
+        "\"--with\"\\n\\s+\"(?<depName>[a-zA-Z0-9][a-zA-Z0-9._-]*)(?:\\[[^\\]]+\\])?==(?<currentValue>[\\d][^\\s\"]*)\"",
+        "\\buv\\S*\\s+tool\\s+install\\s+\"(?<depName>[a-zA-Z0-9][a-zA-Z0-9._-]*)(?:\\[[^\\]]+\\])?==(?<currentValue>[\\d][^\\s\"]*)\""
+      ],
+      "datasourceTemplate": "pypi"
+    },
+    {
       "description": "npx version pins in GitHub Actions workflows annotated with renovate comments",
       "customType": "regex",
       "fileMatch": ["\\.github/workflows/.*\\.ya?ml$"],


### PR DESCRIPTION
## Summary

- Upstream generic Nix ecosystem custom managers from nix-ai so all repos inherit them
- npm packages in Nix string literals (`"@scope/pkg@version"`) and bunx `--bun` wrappers
- uv/uvx PyPI packages: `--from`, `--with`, `uv tool install` patterns in `.nix` files

## Changes

Two new `customManagers` added to `renovate-presets.json`:
1. **npm-in-nix**: Matches `"@scope/pkg@version"` and `bunx --bun pkg@version` in `.nix` files
2. **uv/uvx-in-nix**: Matches all uvx/uv pin patterns across multiline Nix args

## Test plan

- [ ] Validate Renovate config: `npx renovate-config-validator renovate-presets.json`
- [ ] After merge: verify nix-ai Renovate detects pinned packages via inherited preset

Closes #156
Related: JacobPEvans/nix-ai#435

🤖 Generated with [Claude Code](https://claude.com/claude-code)