### PR TITLE
feat(nix-validate): add runner_label input for self-hosted runner opt-in

### DIFF
--- a/.github/workflows/_nix-validate.yml
+++ b/.github/workflows/_nix-validate.yml
@@ -4,6 +4,15 @@ name: _nix-validate
 
 on:
   workflow_call:
+    inputs:
+      runner_label:
+        description: >-
+          GitHub Actions runner label to run the validate job on. Defaults to
+          ubuntu-latest. Pass a RunsOn label (see runs-on.com job labels docs)
+          to opt the calling repo into self-hosted runners.
+        type: string
+        required: false
+        default: ubuntu-latest
 
 concurrency:
   group: nix-validate-${{ github.workflow }}-${{ github.ref }}
@@ -15,7 +24,7 @@ permissions:
 jobs:
   validate:
     name: Validate
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner_label }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

- Adds optional `runner_label` workflow_call input to `_nix-validate.yml` (default: `ubuntu-latest`)
- Calling repos can opt into running `nix flake check` on a different runner — typically a RunsOn self-hosted spot runner

## Why

- terraform-runs-on RunsOn deployment is live and validated (smoke test runs in <60s on m8i.large spot)
- nix-home will be the first opt-in consumer via a follow-up PR
- Org-level template change is backwards compatible — `nix-darwin`, `nix-ai`, and `_nix-build.yml` continue to use `ubuntu-latest` by default

## Test plan

- [ ] Merge this PR (no tests in this repo, validated by downstream consumers)
- [ ] Verify nix-darwin / nix-ai PRs still run on ubuntu-latest after merge (default behavior unchanged)
- [ ] Open follow-up PR in nix-home that passes `runner_label: "runs-on=\${{ github.run_id }}/runner=2cpu-linux-x64"` and verify the validate job lands on a RunsOn spot instance