### PR TITLE
fix(release-please): retry transient errors and re-poke stale auto-merge queue

### DIFF
--- a/.github/workflows/_release-please.yml
+++ b/.github/workflows/_release-please.yml
@@ -89,13 +89,16 @@ jobs:
           PR_NUMBER=$(gh pr list --head "release-please--branches--${BASE_BRANCH}" --json number --jq '.[0].number // empty')
           echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
 
-      # Bot approval (github.token) was triggering premature auto-merge evaluation
-      # before CI checks registered, causing auto-merge to get stuck with rulesets
-      # (github/community#162623). Removed; repos requiring approvals will leave
-      # auto-merge pending until the required human reviews are submitted.
-      - name: Enable auto-merge for release PR
+      # Disable+re-enable handles RC3 (stale auto-merge queue: PR is CLEAN with
+      # auto-merge enabled but GitHub never executes the merge). The retry loop
+      # handles RC2 (transient GraphQL errors from `gh pr merge --auto`).
+      # Bot approval was removed earlier (github/community#162623).
+      - name: Enable auto-merge for release PR (with re-poke + retry)
         if: "!cancelled() && steps.find-pr.outputs.number != ''"
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ steps.find-pr.outputs.number }}
-        run: gh pr merge "$PR_NUMBER" --auto --squash
+        run: |
+          gh pr merge "$PR_NUMBER" --disable-auto 2>/dev/null || true
+          for _ in 1 2 3; do gh pr merge "$PR_NUMBER" --auto --squash && exit 0; sleep 15; done
+          exit 1


### PR DESCRIPTION
## Summary

Single minimal change: rewrite the auto-merge enable step in the existing reusable `_release-please.yml` workflow.

**One file modified. Zero new files. Zero new workflows.**

## What this fixes

Two real failure modes that left release-please PRs stuck for days:

| Root cause | Symptom | Fix in this PR |
|---|---|---|
| **RC2** Transient GraphQL error from `gh pr merge --auto` | terraform-proxmox#218 hit `E01C:1B4A61:...` and never recovered (24h+ stuck) | Retry up to 3 times with 15s sleep |
| **RC3** Stale auto-merge queue (CLEAN+enabled but not executing) | ai-workflows#134 stuck 21h, ansible-splunk#123 stuck 58h | Disable+re-enable to re-poke the queue |

All 3 PRs were unstuck manually before this PR was opened (PR #218 with direct `gh pr merge --auto`, PRs #134/#123 with `disable + re-enable`). Each merged within seconds, confirming the diagnosis.

## The diff

```diff
-      - name: Enable auto-merge for release PR
+      - name: Enable auto-merge for release PR (with re-poke + retry)
         if: "!cancelled() && steps.find-pr.outputs.number != ''"
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ steps.find-pr.outputs.number }}
-        run: gh pr merge "$PR_NUMBER" --auto --squash
+        run: |
+          gh pr merge "$PR_NUMBER" --disable-auto 2>/dev/null || true
+          for _ in 1 2 3; do gh pr merge "$PR_NUMBER" --auto --squash && exit 0; sleep 15; done
+          exit 1
```

3 lines of bash:
1. **Disable** any existing auto-merge state (no-op if not enabled). This re-pokes a possibly-stale queue.
2. **Retry** the enable up to 3 times with 15s between attempts. Catches transient GraphQL errors.
3. **Exit 1** if all 3 attempts fail (workflow surfaces the failure).

## What this does NOT do

This PR is intentionally narrow. The previous version of #159 tried to address every related problem at once and was rightly rejected as over-engineered. Items deferred to separate (or no) PRs:

- Renovate PR auto-merge (Renovate has its own platformAutomerge mechanism; not in scope here)
- Cross-repo ruleset standardization
- Removing `code_quality` / `copilot_code_review` ruleset rules
- Outlier remediation (terraform-aws-bedrock, etc.)
- A scheduled "healer" workflow

If RC2/RC3 still cause stuck PRs after this lands, we add the smallest possible additional mitigation in a follow-up PR — not a kitchen-sink rewrite.

## Test plan

- [ ] Merge this PR
- [ ] Wait for the next release-please PR in any consuming repo
- [ ] Verify the workflow logs show "Auto-merge enabled on attempt 1." (or recovers on retry)
- [ ] Confirm the release PR auto-merges within ~5 minutes of CI passing
- [ ] If a stuck PR appears in the future, verify the next push to main triggers release-please which will re-poke and retry it