### PR TITLE
feat(automerge): scheduled sweep for stale auto-merge queue

### DIFF
--- a/.github/workflows/automerge-sweep.yml
+++ b/.github/workflows/automerge-sweep.yml
@@ -49,7 +49,6 @@ jobs:
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           owner: JacobPEvans
           repositories: ${{ matrix.repo }}
-          permission-contents: write
           permission-pull-requests: write
 
       - name: Poke stuck trusted PRs

--- a/.github/workflows/automerge-sweep.yml
+++ b/.github/workflows/automerge-sweep.yml
@@ -12,14 +12,16 @@ on:
     - cron: "*/10 * * * *"
   workflow_dispatch:
 
+concurrency:
+  group: automerge-sweep
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:
   sweep:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
+    permissions: {}
     strategy:
       fail-fast: false
       matrix:
@@ -55,18 +57,29 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           REPO: ${{ matrix.repo }}
         run: |
-          gh pr list -R "JacobPEvans/${REPO}" --state open \
+          gh pr list -R "JacobPEvans/${REPO}" --state open --limit 1000 \
             --json number,author,autoMergeRequest,mergeStateStatus,isDraft \
             --jq '
               .[] | select(
                 .isDraft == false and
-                (.author.login | test("^(renovate|dependabot|jacobpevans-github-actions)")) and
+                (.author.login | test("^(renovate\\[bot\\]|dependabot\\[bot\\]|jacobpevans-github-actions\\[bot\\])$")) and
                 (.autoMergeRequest != null) and
                 (.mergeStateStatus == "CLEAN")
-              ) | .number
-            ' | while read -r pr; do
+              ) | [.number, .autoMergeRequest.mergeMethod] | @tsv
+            ' | while IFS=$'\t' read -r pr merge_method; do
               echo "Poking JacobPEvans/${REPO}#${pr}"
-              gh pr merge "${pr}" -R "JacobPEvans/${REPO}" --disable-auto 2>/dev/null || true
+              case "${merge_method}" in
+                MERGE)  merge_flag="--merge"  ;;
+                REBASE) merge_flag="--rebase" ;;
+                SQUASH) merge_flag="--squash" ;;
+                *)
+                  echo "::warning::Unknown merge method '${merge_method}' for JacobPEvans/${REPO}#${pr}; defaulting to --squash"
+                  merge_flag="--squash"
+                  ;;
+              esac
+              gh pr merge "${pr}" -R "JacobPEvans/${REPO}" --disable-auto 2>/dev/null \
+                || echo "::warning::Failed to disable auto-merge for JacobPEvans/${REPO}#${pr}"
               sleep 2
-              gh pr merge "${pr}" -R "JacobPEvans/${REPO}" --auto --squash || true
+              gh pr merge "${pr}" -R "JacobPEvans/${REPO}" --auto "${merge_flag}" \
+                || echo "::warning::Failed to re-enable auto-merge for JacobPEvans/${REPO}#${pr}"
             done

--- a/.github/workflows/automerge-sweep.yml
+++ b/.github/workflows/automerge-sweep.yml
@@ -1,0 +1,72 @@
+# Automerge Sweep
+#
+# GitHub's auto-merge queue sometimes goes stale (RC3): a PR has
+# mergeStateStatus=CLEAN and autoMergeRequest set, but GitHub never
+# executes the merge.  Toggling auto-merge off/on forces re-evaluation.
+#
+# Runs every 10 minutes.  Idempotent — safe to run on any schedule.
+name: automerge-sweep
+
+on:
+  schedule:
+    - cron: "*/10 * * * *"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  sweep:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    strategy:
+      fail-fast: false
+      matrix:
+        repo:
+          - nix-darwin
+          - nix-ai
+          - nix-home
+          - nix-devenv
+          - ai-workflows
+          - ai-assistant-instructions
+          - ansible-proxmox
+          - ansible-proxmox-apps
+          - ansible-splunk
+          - terraform-proxmox
+          - terraform-aws-bedrock
+          - terraform-aws-static-website
+          - terraform-runs-on
+          - orbstack-kubernetes
+    steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.GH_ACTION_JACOBPEVANS_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: JacobPEvans
+          repositories: ${{ matrix.repo }}
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Poke stuck trusted PRs
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ matrix.repo }}
+        run: |
+          gh pr list -R "JacobPEvans/${REPO}" --state open \
+            --json number,author,autoMergeRequest,mergeStateStatus,isDraft \
+            --jq '
+              .[] | select(
+                .isDraft == false and
+                (.author.login | test("^(renovate|dependabot|jacobpevans-github-actions)")) and
+                (.autoMergeRequest != null) and
+                (.mergeStateStatus == "CLEAN")
+              ) | .number
+            ' | while read -r pr; do
+              echo "Poking JacobPEvans/${REPO}#${pr}"
+              gh pr merge "${pr}" -R "JacobPEvans/${REPO}" --disable-auto 2>/dev/null || true
+              sleep 2
+              gh pr merge "${pr}" -R "JacobPEvans/${REPO}" --auto --squash || true
+            done


### PR DESCRIPTION
# PR #162 Metadata Update

## Summary

- Adds `automerge-sweep.yml` — a 70-line cron workflow that runs every 10 minutes
- Finds open PRs from trusted bots (renovate, dependabot, jacobpevans-github-actions) where
  auto-merge is enabled + `mergeStateStatus == CLEAN` but GitHub hasn't executed the merge
- Toggles auto-merge off/on to force GitHub to re-evaluate (proven fix for RC3 stale queue
  bug)
- Uses the same GitHub App token as release-please for consistent identity
- Replaces the unmerged `feat/automerge-reliability` branch (500+ lines, 3 scripts) with
  minimal code

## Context

GitHub's native auto-merge queue sometimes goes stale — a PR has all checks green,
auto-merge enabled, and `mergeStateStatus=CLEAN`, but the merge never executes. The only
known fix is toggling auto-merge off/on. The existing inline retry in `_release-please.yml`
handles initial creation, but nothing catches the stale queue after that. PRs were sitting
for 1-2 hours before eventual manual intervention.

## Changes

1. **feat(automerge)**: Initial scheduled sweep implementation — cron workflow to detect and
   poke stale auto-merge queue every 10 minutes
2. **fix(automerge)**: Address Copilot review feedback — refined concurrency control,
   permissions scoping, result limits, regex patterns, merge method handling, and error
   surfacing

## Test Plan

- [x] Manual toggle on `ansible-proxmox-apps#177` — merged instantly after poke
- [x] Manual toggle on `nix-ai#492` — checks re-running, will merge on completion
- [ ] Run `gh workflow run automerge-sweep.yml` after merge to verify cron works
- [ ] Observe next release-please or renovate PR merges within 10 min without intervention

## Related

- #21 — Broader dependency automation context (Renovate dependency updates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
