### PR TITLE
feat(cspell): expand shared dict with cross-repo terms

### DIFF
--- a/cspell/dicts/devtools.txt
+++ b/cspell/dicts/devtools.txt
@@ -2,9 +2,13 @@
 # Linters, test runners, commit/release automation, git workflow terms.
 
 # Linters & formatters
+argjson
 commitlintrc
 deadnix
+ghostty
+schemafile
 statix
+treefmt
 zizmor
 
 # Test & runtime

--- a/cspell/dicts/infrastructure.txt
+++ b/cspell/dicts/infrastructure.txt
@@ -17,8 +17,23 @@ sourcetype
 sourcetypes
 tempo
 
+# Linux / macOS system tools
+bootout
+procps
+tmpfs
+
+# Networking / homelab
+homelab
+ubiquiti
+unifi
+
 # IaC & deployment
 ansiblelint
+crbl
+endfor
+equalto
+fqcn
+selectattr
 fluxcd
 hostvars
 kubeconform

--- a/cspell/dicts/infrastructure.txt
+++ b/cspell/dicts/infrastructure.txt
@@ -32,15 +32,15 @@ ansiblelint
 crbl
 endfor
 equalto
-fqcn
-selectattr
 fluxcd
+fqcn
 hostvars
 kubeconform
 kubectx
 kubens
 kubeval
 orbstack
+selectattr
 
 # Secrets & identity
 doppler

--- a/cspell/dicts/nix-ecosystem.txt
+++ b/cspell/dicts/nix-ecosystem.txt
@@ -19,3 +19,4 @@ nixpkgs
 passthru
 pkgs
 pmset
+stdenv

--- a/cspell/dicts/org.txt
+++ b/cspell/dicts/org.txt
@@ -1,7 +1,9 @@
 # JacobPEvans org identifiers, project names, shared code references.
 
 agentsmd
+hookify
 jacobpevans
 jevans
+macbook
 raycast-smart-issue
 visicore


### PR DESCRIPTION
## Summary

Add terms discovered across consumer repos during shared dictionary migration to eliminate duplication. Also fix sort order in IaC section for consistency.

## Changes

- **infrastructure.txt** (+11): bootout, procps, tmpfs, homelab, ubiquiti, unifi, crbl, endfor, equalto, fqcn, selectattr
- **devtools.txt** (+4): argjson, ghostty, schemafile, treefmt
- **nix-ecosystem.txt** (+1): stdenv
- **org.txt** (+2): hookify, macbook
- IaC & deployment section: alphabetically sorted (fluxcd before selectattr)

Terms identified by analyzing 13 consumer repos (orbstack-kubernetes, nix-ai, secrets-sync, etc.) to ensure they don't need local dictionary duplicates.

## Test plan

- [x] `pre-commit run cspell --all-files` passes
- [ ] CI passes