### PR TITLE
fix(ci): revert setup-uv to @v7 — v8 major tag not yet published

### DIFF
--- a/.github/workflows/_python-security.yml
+++ b/.github/workflows/_python-security.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
 
       - name: Audit Python dependencies
         env:


### PR DESCRIPTION
## Summary

- Revert `astral-sh/setup-uv` from `@v8` back to `@v7` in `_python-security.yml`
- The `v8` major tag doesn't exist yet — only `v8.0.0` and `v8.1.0` point releases
- Renovate auto-merged #191 which broke Python Security CI across all repos

## Impact

Every repo with Python deps (`nix-ai`, `ansible-splunk`, `ansible-proxmox-apps`) has failing pip-audit CI since this merged.

## Test plan

- [ ] CI passes on this PR
- [ ] After merge: re-run nix-ai #556 CI and confirm pip-audit passes

Renovate will re-propose `@v8` once astral-sh publishes the major tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)