### PR TITLE
fix(deps): stop Renovate editing gh-aw generated files; add pin-refresh workflow

### DIFF
--- a/.github/workflows/_gh-aw-pin-refresh.yml
+++ b/.github/workflows/_gh-aw-pin-refresh.yml
@@ -56,6 +56,8 @@ jobs:
         with:
           app-id: ${{ secrets.GH_ACTION_JACOBPEVANS_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
 
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/_gh-aw-pin-refresh.yml
+++ b/.github/workflows/_gh-aw-pin-refresh.yml
@@ -9,6 +9,9 @@
 #
 #   jobs:
 #     refresh:
+#       permissions:
+#         contents: write
+#         pull-requests: write
 #       uses: JacobPEvans/.github/.github/workflows/_gh-aw-pin-refresh.yml@main
 #       with:
 #         operation: compile   # or 'upgrade' for full gh-aw infrastructure update
@@ -61,7 +64,7 @@ jobs:
       - name: Install gh-aw CLI
         uses: github/gh-aw-actions/setup-cli@v0.68.3
         with:
-          version: latest
+          version: v0.68.3
 
       - name: Refresh action pins
         env:

--- a/.github/workflows/_gh-aw-pin-refresh.yml
+++ b/.github/workflows/_gh-aw-pin-refresh.yml
@@ -1,0 +1,90 @@
+# Reusable: gh-aw action pin refresh
+# Refreshes SHA pins in gh-aw generated files via `gh aw compile --force-refresh-action-pins`.
+#
+# Replaces Renovate for generated gh-aw files, which Renovate cannot update correctly
+# (Renovate only patches `uses:` lines but leaves manifest JSON and actions-lock.json
+# inconsistent).
+#
+# Usage from a caller workflow:
+#
+#   jobs:
+#     refresh:
+#       uses: JacobPEvans/.github/.github/workflows/_gh-aw-pin-refresh.yml@main
+#       with:
+#         operation: compile   # or 'upgrade' for full gh-aw infrastructure update
+#       secrets:
+#         GH_ACTION_JACOBPEVANS_APP_ID: ${{ secrets.GH_ACTION_JACOBPEVANS_APP_ID }}
+#         GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
+#
+# Secrets required:
+#   GH_ACTION_JACOBPEVANS_APP_ID  - GitHub App ID
+#   GH_APP_PRIVATE_KEY            - GitHub App private key
+#
+# The GitHub App token is required so the resulting PR triggers `pull_request`
+# workflows (e.g. CI gate, CodeQL). PRs created with GITHUB_TOKEN do NOT trigger them.
+# The App also satisfies `required_signatures` branch protection.
+name: _gh-aw-pin-refresh
+
+on:
+  workflow_call:
+    inputs:
+      operation:
+        description: 'compile = refresh SHA pins only; upgrade = full gh-aw infrastructure update'
+        type: string
+        default: 'compile'
+    secrets:
+      GH_ACTION_JACOBPEVANS_APP_ID:
+        required: true
+      GH_APP_PRIVATE_KEY:
+        required: true
+
+permissions: {}
+
+jobs:
+  refresh-pins:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.GH_ACTION_JACOBPEVANS_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v6
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Install gh-aw CLI
+        uses: github/gh-aw-actions/setup-cli@v0.68.3
+        with:
+          version: latest
+
+      - name: Refresh action pins
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_AW_OPERATION: ${{ inputs.operation }}
+        run: |
+          if [ "$GH_AW_OPERATION" = "upgrade" ]; then
+            gh aw upgrade
+          else
+            gh aw compile --force-refresh-action-pins
+          fi
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          branch: gh-aw/refresh-action-pins
+          delete-branch: true
+          title: "fix(deps): refresh gh-aw action SHA pins"
+          body: |
+            Automated refresh of action SHA pins via `gh aw compile --force-refresh-action-pins`.
+
+            Updates `actions-lock.json`, all `*.lock.yml` workflows, and
+            `agentics-maintenance.yml` with consistent, freshly-resolved SHAs.
+          labels: dependencies
+          commit-message: "fix(deps): refresh gh-aw action SHA pins"

--- a/.github/workflows/gh-aw-pin-refresh.yml
+++ b/.github/workflows/gh-aw-pin-refresh.yml
@@ -1,0 +1,26 @@
+name: gh-aw pin refresh
+
+on:
+  schedule:
+    - cron: "0 12 * * 1"  # Monday 7am CT
+    - cron: "0 12 * * 4"  # Thursday 7am CT
+  workflow_dispatch:
+    inputs:
+      operation:
+        description: 'compile = refresh SHA pins only; upgrade = full gh-aw infrastructure update'
+        type: choice
+        default: 'compile'
+        options:
+          - compile
+          - upgrade
+
+permissions: {}
+
+jobs:
+  refresh:
+    uses: JacobPEvans/.github/.github/workflows/_gh-aw-pin-refresh.yml@main
+    with:
+      operation: ${{ inputs.operation }}
+    secrets:
+      GH_ACTION_JACOBPEVANS_APP_ID: ${{ secrets.GH_ACTION_JACOBPEVANS_APP_ID }}
+      GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}

--- a/.github/workflows/gh-aw-pin-refresh.yml
+++ b/.github/workflows/gh-aw-pin-refresh.yml
@@ -2,8 +2,8 @@ name: gh-aw pin refresh
 
 on:
   schedule:
-    - cron: "0 12 * * 1"  # Monday 7am CT
-    - cron: "0 12 * * 4"  # Thursday 7am CT
+    - cron: "0 12 * * 1"  # Monday 12:00 UTC (7am CDT / 6am CST)
+    - cron: "0 12 * * 4"  # Thursday 12:00 UTC (7am CDT / 6am CST)
   workflow_dispatch:
     inputs:
       operation:
@@ -16,11 +16,18 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: gh-aw-pin-refresh
+  cancel-in-progress: false
+
 jobs:
   refresh:
+    permissions:
+      contents: write
+      pull-requests: write
     uses: JacobPEvans/.github/.github/workflows/_gh-aw-pin-refresh.yml@main
     with:
-      operation: ${{ inputs.operation }}
+      operation: ${{ inputs.operation || 'compile' }}
     secrets:
       GH_ACTION_JACOBPEVANS_APP_ID: ${{ secrets.GH_ACTION_JACOBPEVANS_APP_ID }}
       GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}

--- a/renovate-presets.json
+++ b/renovate-presets.json
@@ -5,6 +5,11 @@
   "automergeType": "pr",
   "automergeStrategy": "squash",
   "pinGitHubActionDigests": true,
+  "ignorePaths": [
+    ".github/workflows/*.lock.yml",
+    ".github/workflows/agentics-maintenance.yml",
+    ".github/aw/**"
+  ],
   "minimumReleaseAge": "3 days",
   "timezone": "America/Chicago",
   "vulnerabilityAlerts": {


### PR DESCRIPTION
# PR #193: Stop Renovate from editing gh-aw generated files

## Summary

**Problem**: Renovate's GitHub Actions manager was treating gh-aw generated files
(`.lock.yml`, `agentics-maintenance.yml`) as normal workflows. It only patched
`uses:` lines, leaving `gh-aw-manifest` JSON metadata and `actions-lock.json`
inconsistent — 3 independently drifted layers per generated file. ~16 PRs merged
in 5 days, all creating internally inconsistent output that would be overwritten
on the next `gh aw compile`.

**Solution**: Stop Renovate from editing generated files entirely. Replace with a
dedicated `gh-aw-pin-refresh` workflow that runs `gh aw compile --force-refresh-action-pins`
on a regular schedule, producing a single consolidated PR with atomically consistent
lock file updates.

## Changes

1. **`renovate-presets.json`** — Added `ignorePaths` for `*.lock.yml`,
   `agentics-maintenance.yml`, `.github/aw/**` (org-wide, DRY — any repo extending
   this preset gets exclusions automatically)

2. **`.github/workflows/_gh-aw-pin-refresh.yml`** — New reusable workflow that:
   - Installs pinned gh-aw CLI (v0.68.3)
   - Runs `gh aw compile --force-refresh-action-pins` (safe refresh of action pins
     only)
   - Creates a single consolidated PR with atomic lock file updates
   - Uses explicit GitHub App token permissions (matches `_release-please.yml`
     pattern)
   - Accepts `compile` or `upgrade` operations via workflow input

3. **`.github/workflows/gh-aw-pin-refresh.yml`** — New caller workflow that:
   - Runs on Mon/Thu schedule (matching existing Renovate lock-file-maintenance
     cadence)
   - Supports manual `workflow_dispatch` with `operation` input
   - Uses concurrency group with `cancel-in-progress: false` (queue rather than
     cancel)

4. **Permission scopes refinement** — Explicit GitHub App token scopes in both
   workflows (contents:write, pull-requests:write, pull-requests:read)

## Test Plan

- [ ] After merge: trigger `gh-aw-pin-refresh` via `workflow_dispatch`
  (operation=`compile`) and verify a clean, internally consistent PR is produced
- [ ] Confirm Renovate stops creating PRs targeting `.lock.yml` and
  `agentics-maintenance.yml`
- [ ] Follow-up PR: run `gh aw compile --force-refresh-action-pins` locally to
  reconcile current drift
- [ ] Verify Monday/Thursday scheduled runs execute successfully in the future

Closes #177
