### PR TITLE
fix(renovate): disable platformAutomerge — let Renovate merge directly

### DIFF
--- a/renovate-presets.json
+++ b/renovate-presets.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "description": "JacobPEvans org-wide Renovate preset",
-  "platformAutomerge": true,
+  "platformAutomerge": false,
   "automergeType": "pr",
   "automergeStrategy": "squash",
   "pinGitHubActionDigests": true,

--- a/renovate-presets.json
+++ b/renovate-presets.json
@@ -1,26 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "description": "JacobPEvans org-wide Renovate preset",
-
-  // ============================================================================
-  // DO NOT set platformAutomerge to true.
-  //
-  // GitHub's native auto-merge queue has a known bug (RC3) where PRs pass all
-  // checks, show mergeStateStatus=CLEAN with autoMergeRequest set, and GitHub
-  // simply never executes the merge. PRs stall for days with no error.
-  //
-  // With platformAutomerge=false, Renovate handles the merge directly via API
-  // on its next run cycle (~1hr worst case). Same signed squash commits, same
-  // branch protection compliance, but with built-in retry logic instead of
-  // relying on GitHub's flaky event-driven queue.
-  //
-  // History: Multiple workaround attempts were tried and abandoned:
-  //   - PR #162: automerge-sweep.yml (scheduled poke every 10min across 14 repos)
-  //   - feat/automerge-reliability: 500-line automerge-healer.yml
-  // All were complex workarounds. This one-line fix is the actual solution.
-  //
-  // Changed: 2026-04-17 (PR #196)
-  // ============================================================================
+  "description": [
+    "JacobPEvans org-wide Renovate preset",
+    "WARNING: platformAutomerge MUST stay false. GitHub's auto-merge queue has a known bug (RC3) where PRs pass all checks but GitHub never executes the merge — PRs stall for days with no error. With false, Renovate merges directly via API with built-in retry logic. See PR #196 for full history. Do NOT set this to true."
+  ],
   "platformAutomerge": false,
   "automergeType": "pr",
   "automergeStrategy": "squash",

--- a/renovate-presets.json5
+++ b/renovate-presets.json5
@@ -1,6 +1,26 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "description": "JacobPEvans org-wide Renovate preset",
+
+  // ============================================================================
+  // DO NOT set platformAutomerge to true.
+  //
+  // GitHub's native auto-merge queue has a known bug (RC3) where PRs pass all
+  // checks, show mergeStateStatus=CLEAN with autoMergeRequest set, and GitHub
+  // simply never executes the merge. PRs stall for days with no error.
+  //
+  // With platformAutomerge=false, Renovate handles the merge directly via API
+  // on its next run cycle (~1hr worst case). Same signed squash commits, same
+  // branch protection compliance, but with built-in retry logic instead of
+  // relying on GitHub's flaky event-driven queue.
+  //
+  // History: Multiple workaround attempts were tried and abandoned:
+  //   - PR #162: automerge-sweep.yml (scheduled poke every 10min across 14 repos)
+  //   - feat/automerge-reliability: 500-line automerge-healer.yml
+  // All were complex workarounds. This one-line fix is the actual solution.
+  //
+  // Changed: 2026-04-17 (PR #196)
+  // ============================================================================
   "platformAutomerge": false,
   "automergeType": "pr",
   "automergeStrategy": "squash",


### PR DESCRIPTION
## Summary

- Switches `platformAutomerge` from `true` to `false` in the org-wide Renovate preset
- Bypasses GitHub's known RC3 bug (stale auto-merge queue) where PRs sit indefinitely with `mergeStateStatus == CLEAN` but GitHub never executes the merge
- Renovate now handles merges directly via API with built-in retry logic instead of relying on GitHub's flaky event-driven queue

## Why

GitHub's native auto-merge has a known platform bug where the merge queue silently stalls. PRs pass all checks, show as mergeable, have auto-merge enabled — and nothing happens. The previous approach (PR #162) was a complex scheduled workflow to "poke" stale PRs every 10 minutes across 14 repos. That's a workaround, not a fix.

With `platformAutomerge: false`, Renovate polls for check status and calls the merge API directly. Same signed squash commits, same branch protection compliance — just a more reliable merge mechanism.

## Impact

- **28+ repos** inherit this preset — change propagates automatically, no per-repo work needed
- **Trade-off**: ~1hr worst-case merge delay (Renovate poll cycle) vs. seconds when GitHub's queue works, or days when it doesn't
- **No breaking changes**: `automergeStrategy: "squash"` still matches `allowed_merge_methods: ["squash"]` in branch protection

## Cleanup

Closes #162 (automerge-sweep workflow no longer needed)

## Test plan

- [ ] Verify PR merges to main via CodeQL green
- [ ] Wait for next Renovate auto-merge-eligible PR across any repo
- [ ] Confirm PR opens without GitHub's "Auto-merge enabled" badge
- [ ] Confirm Renovate merges the PR after CI passes on its next cycle
- [ ] Monitor for 1 week across repos for regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)