### PR TITLE
feat: add shared retrigger workflow for bot-created PRs

### DIFF
--- a/.github/workflows/_retrigger-pr-checks.yml
+++ b/.github/workflows/_retrigger-pr-checks.yml
@@ -1,0 +1,91 @@
+---
+# Reusable: Retrigger PR Checks for Bot-Created PRs
+#
+# Problem: PRs created by GITHUB_TOKEN (Copilot agentic workflows, Claude actions)
+#          do not emit `pull_request` events. ci-gate.yml never runs.
+#          The required "Merge Gate" status check is permanently missing.
+#
+# Solution: Find bot-authored open PRs missing CI Gate runs.
+#           Use a GitHub App token to close/reopen them, triggering
+#           `pull_request: reopened` which fires ci-gate.yml normally.
+#
+# Safety constraints:
+#   - Only touches PRs by app/github-actions (bot author)
+#   - Skips draft PRs
+#   - Skips commits < 5 minutes old (avoids racing normal CI triggers)
+#   - Caps at 5 PRs per run
+#   - App token scoped to pull-requests: write only
+#   - No user-controlled content interpolated into run commands
+name: _retrigger-pr-checks
+
+on:
+  workflow_call:
+    secrets:
+      GH_ACTION_JACOBPEVANS_APP_ID:
+        required: true
+      GH_APP_PRIVATE_KEY:
+        required: true
+
+permissions: {}
+
+jobs:
+  retrigger:
+    name: Retrigger Missing CI Gate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.GH_ACTION_JACOBPEVANS_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          permission-pull-requests: write
+
+      - name: Retrigger bot PRs missing CI Gate
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          FIVE_MIN_AGO=$(date -u -d '5 minutes ago' +%s 2>/dev/null || date -u -v-5M +%s)
+          COUNT=0
+
+          while IFS= read -r line; do
+            NUMBER=$(echo "$line" | jq -r '.number')
+            SHA=$(echo "$line" | jq -r '.headRefOid')
+            IS_DRAFT=$(echo "$line" | jq -r '.isDraft')
+
+            [ "$IS_DRAFT" = "true" ] && continue
+
+            # Skip commits less than 5 minutes old (avoid racing normal CI triggers)
+            COMMIT_DATE=$(gh api "repos/${REPO}/commits/${SHA}" \
+              --jq '.commit.committer.date' 2>/dev/null || echo "")
+            [ -z "$COMMIT_DATE" ] && continue
+            COMMIT_TS=$(date -u -d "$COMMIT_DATE" +%s 2>/dev/null \
+              || date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$COMMIT_DATE" +%s)
+            [ "$COMMIT_TS" -gt "$FIVE_MIN_AGO" ] && continue
+
+            # Skip if CI Gate already ran for this SHA
+            RUN_COUNT=$(gh api \
+              "repos/${REPO}/actions/workflows/ci-gate.yml/runs?head_sha=${SHA}&per_page=1" \
+              --jq '.total_count' 2>/dev/null || echo "1")
+            [ "$RUN_COUNT" -gt 0 ] && continue
+
+            echo "Retriggering PR #${NUMBER} (SHA: ${SHA})"
+            GH_TOKEN="$APP_TOKEN" gh pr close "$NUMBER" --repo "$REPO"
+            GH_TOKEN="$APP_TOKEN" gh pr reopen "$NUMBER" --repo "$REPO"
+
+            COUNT=$((COUNT + 1))
+            [ "$COUNT" -ge 5 ] && break
+
+          done < <(gh pr list \
+            --repo "$REPO" \
+            --state open \
+            --author "app/github-actions" \
+            --json number,headRefOid,isDraft \
+            --jq '.[]')
+
+          echo "Retriggered ${COUNT} PR(s)."

--- a/.github/workflows/_retrigger-pr-checks.yml
+++ b/.github/workflows/_retrigger-pr-checks.yml
@@ -33,6 +33,7 @@ jobs:
     name: Retrigger Missing CI Gate
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: read
       pull-requests: read
     steps:


### PR DESCRIPTION
## Summary

- Bot-created PRs (Copilot agentic workflows, Claude actions) use `GITHUB_TOKEN`, which does not emit `pull_request` events
- `ci-gate.yml` never triggers → required **Merge Gate** check permanently missing → PR blocked
- `_release-please.yml` already documents this exact problem (line 29)

Adds `_retrigger-pr-checks.yml` — a reusable workflow called by consumer repos 3×/day. It:
1. Lists open non-draft PRs authored by `app/github-actions`
2. Skips commits < 5 min old (avoid racing normal CI triggers)
3. Checks if CI Gate already ran for the head SHA (idempotent, requires `actions: read`)
4. Closes/reopens with GitHub App token → triggers `pull_request: reopened` → `ci-gate.yml` fires

**Security**: only touches bot PRs, App token scoped to `pull-requests: write` only, no user-controlled content in shell commands.

**DRY**: one shared workflow. Consumer repos get a 15-line thin caller each.

## Changes

- `feat: add shared retrigger workflow for bot-created PRs`
- `fix: add actions: read permission for CI Gate run check` — without this, the Actions API call 403s and the `|| echo "1"` fallback causes every PR to be silently skipped

## Affected repos (caller will be added in separate PRs)

`ansible-splunk`, `ansible-proxmox`, `terraform-proxmox`, `nix-ai`, `nix-home`

## Test plan

- [ ] Merge to `.github` main
- [ ] Add caller to `ansible-splunk`, run `workflow_dispatch`
- [ ] Verify PR #166 closes/reopens → CI Gate fires → Merge Gate appears → unblocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)
