### PR TITLE
fix(renovate): add packageRules failsafe to prevent gh-aw lock file updates

### DIFF
--- a/renovate-presets.json
+++ b/renovate-presets.json
@@ -70,6 +70,15 @@
   ],
   "packageRules": [
     {
+      "description": "Disable all updates in gh-aw generated files — managed by gh-aw-pin-refresh workflow, not Renovate",
+      "matchFileNames": [
+        ".github/workflows/*.lock.yml",
+        ".github/workflows/agentics-maintenance.yml",
+        ".github/aw/**"
+      ],
+      "enabled": false
+    },
+    {
       "description": "Never auto-merge major updates - require human review (overridden by trusted package rules below)",
       "matchUpdateTypes": ["major"],
       "automerge": false


### PR DESCRIPTION
## Summary

- Adds `packageRules` entry with `matchFileNames` + `enabled: false` as belt-and-suspenders protection for gh-aw generated files
- Complements existing `ignorePaths` (prevents scanning) with a second layer that suppresses any updates that slip through extraction
- Part of a multi-repo fix for recurring `[aw] AI Moderator failed` issues across the org

## Root cause

Renovate patched `uses:` SHA pins inside `.lock.yml` files without updating the `gh-aw-manifest` JSON or `actions-lock.json`, breaking hash integrity. The `ignorePaths` config added in PR #193 proved insufficient — Renovate continued patching because the `github-actions` manager processes action refs at extraction time, and `ignorePaths` doesn't reliably block extraction for all managers when `pinGitHubActionDigests: true` is set.

## Changes

- `renovate-presets.json`: New `packageRules` entry added as **first rule** (highest priority):
  - `matchFileNames`: `.github/workflows/*.lock.yml`, `.github/workflows/agentics-maintenance.yml`, `.github/aw/**`
  - `enabled: false` — suppresses all updates for dependencies found in these generated files

## Why both layers

| Defense | Mechanism | When it applies |
|---------|-----------|-----------------|
| `ignorePaths` | Prevents Renovate from *scanning* matched files | Pre-extraction |
| `packageRules` + `matchFileNames` + `enabled: false` | Suppresses updates for deps extracted from matched files | Post-extraction |

Per Renovate docs, this two-layer approach is recommended for protecting generated files managed by a separate automation.

## Test plan

- [ ] Renovate runs after merge — confirm no PRs for `.github/workflows/*.lock.yml` files appear
- [ ] `gh-aw-pin-refresh` workflow (deployed by companion PRs) runs clean without interference

## Related

Lock file recompile + pin-refresh rollout companion PRs (all 13 consumer repos):
JacobPEvans/nix-home#191 · JacobPEvans/nix-ai#602 · JacobPEvans/nix-darwin#1036 · JacobPEvans/ansible-proxmox#137 · JacobPEvans/ansible-proxmox-apps#215 · JacobPEvans/tf-splunk-aws#135 · JacobPEvans/python-template#38 · JacobPEvans/claude-code-plugins#239 · JacobPEvans/ai-workflows#169 · JacobPEvans/orbstack-kubernetes#188 · JacobPEvans/terraform-aws-bedrock#45 · JacobPEvans/ai-assistant-instructions#593 · JacobPEvans/ansible-splunk#168

Generated with [Claude Code](https://claude.com/claude-code)
