### PR TITLE
fix(ci): add workflows permission to gh-aw-pin-refresh App token request

### DIFF
--- a/.github/workflows/_gh-aw-pin-refresh.yml
+++ b/.github/workflows/_gh-aw-pin-refresh.yml
@@ -12,6 +12,7 @@
 #       permissions:
 #         contents: write
 #         pull-requests: write
+#         workflows: write
 #       uses: JacobPEvans/.github/.github/workflows/_gh-aw-pin-refresh.yml@main
 #       with:
 #         operation: compile   # or 'upgrade' for full gh-aw infrastructure update
@@ -49,6 +50,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      workflows: write
     steps:
       - name: Generate GitHub App Token
         id: app-token
@@ -58,6 +60,7 @@ jobs:
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write
+          permission-workflows: write
 
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/gh-aw-pin-refresh.yml
+++ b/.github/workflows/gh-aw-pin-refresh.yml
@@ -25,6 +25,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      workflows: write
     uses: JacobPEvans/.github/.github/workflows/_gh-aw-pin-refresh.yml@main
     with:
       operation: ${{ inputs.operation || 'compile' }}


### PR DESCRIPTION
## Summary

- Adds `permission-workflows: write` to the `actions/create-github-app-token` step in `_gh-aw-pin-refresh.yml`
- Adds `workflows: write` to the job-level `permissions` block in both the reusable and caller workflows

## Root cause

`actions/create-github-app-token` only grants the permissions explicitly listed via `permission-*` inputs. The token was requesting `contents` and `pull-requests` but not `workflows`, causing GitHub to reject pushes to `.github/workflows/` files with:

> refusing to allow a GitHub App to create or update workflow files without `workflows` permission

## Scope

All 13 consumer repos call `_gh-aw-pin-refresh.yml@main`, so this single fix applies org-wide without touching each consumer repo.