### PR TITLE
fix(ci): remove invalid workflows scope from permissions blocks

### DIFF
--- a/.github/workflows/_gh-aw-pin-refresh.yml
+++ b/.github/workflows/_gh-aw-pin-refresh.yml
@@ -12,7 +12,6 @@
 #       permissions:
 #         contents: write
 #         pull-requests: write
-#         workflows: write
 #       uses: JacobPEvans/.github/.github/workflows/_gh-aw-pin-refresh.yml@main
 #       with:
 #         operation: compile   # or 'upgrade' for full gh-aw infrastructure update
@@ -50,7 +49,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-      workflows: write
     steps:
       - name: Generate GitHub App Token
         id: app-token

--- a/.github/workflows/gh-aw-pin-refresh.yml
+++ b/.github/workflows/gh-aw-pin-refresh.yml
@@ -25,7 +25,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-      workflows: write
     uses: JacobPEvans/.github/.github/workflows/_gh-aw-pin-refresh.yml@main
     with:
       operation: ${{ inputs.operation || 'compile' }}


### PR DESCRIPTION
## Summary

Removes `workflows: write` from GitHub Actions `permissions` blocks — it is not a valid scope and caused workflow parse errors:

> Unexpected value 'workflows'

## Root cause

Previous PR #209 correctly added `permission-workflows: write` to `actions/create-github-app-token` (the right fix — that's how GitHub App tokens get the `workflows` permission). But it also added `workflows: write` to the `permissions:` blocks, which is invalid syntax in GitHub Actions YAML.

The `permissions:` block only accepts GitHub Actions token scopes (`contents`, `pull-requests`, `actions`, etc.) — not GitHub App permission names. The App token's permissions are controlled exclusively via `permission-*` inputs to `create-github-app-token`.

## What this keeps

`permission-workflows: write` in `actions/create-github-app-token@v3` — this is correct and stays.