### PR TITLE
fix(ci): enable signed commits in gh-aw-pin-refresh

### DIFF
--- a/.github/workflows/_gh-aw-pin-refresh.yml
+++ b/.github/workflows/_gh-aw-pin-refresh.yml
@@ -25,7 +25,8 @@
 #
 # The GitHub App token is required so the resulting PR triggers `pull_request`
 # workflows (e.g. CI gate, CodeQL). PRs created with GITHUB_TOKEN do NOT trigger them.
-# The App also satisfies `required_signatures` branch protection.
+# `sign-commits: true` in create-pull-request satisfies `required_signatures` branch protection
+# by creating commits via the GitHub API (signed) rather than local `git commit` (unsigned).
 name: _gh-aw-pin-refresh
 
 on:
@@ -84,6 +85,7 @@ jobs:
         uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ steps.app-token.outputs.token }}
+          sign-commits: true
           branch: gh-aw/refresh-action-pins
           delete-branch: true
           title: "fix(deps): refresh gh-aw action SHA pins"


### PR DESCRIPTION
## Summary

Adds `sign-commits: true` to the `peter-evans/create-pull-request@v8` step and fixes an incorrect comment.

## Root cause

`peter-evans/create-pull-request` creates commits via local `git commit` + push by default. These commits are **unsigned**, failing repos with `required_signatures` branch protection. The `token` input is used only for pushing and PR creation — not commit signing.

With `sign-commits: true`, the action creates commits via the GitHub API instead, which produces **verified/signed commits**.

## Scope

Single change to the reusable workflow. All 13 consumer repos call `_gh-aw-pin-refresh.yml@main`, so this fix is org-wide. Already used in `nix-ai`, `nix-home`, `nix-darwin`, `ai-workflows`, `nix-screenpipe` with the same action.

## Follow-up

After merge: close nix-home#193 and nix-ai#604 (unsigned commits), delete their `gh-aw/refresh-action-pins` branches, and re-trigger the workflow in both repos to open fresh PRs with signed commits.