### PR TITLE
fix(renovate): add baseBranchPatterns to target default branch

### DIFF
--- a/renovate-presets.json
+++ b/renovate-presets.json
@@ -5,6 +5,7 @@
     "WARNING: platformAutomerge MUST stay false. GitHub's auto-merge queue has a known bug (RC3) where PRs pass all checks but GitHub never executes the merge — PRs stall for days with no error. With false, Renovate merges directly via API with built-in retry logic. See PR #196 for full history. Do NOT set this to true."
   ],
   "platformAutomerge": false,
+  "baseBranchPatterns": ["$default"],
   "automergeType": "pr",
   "automergeStrategy": "squash",
   "pinGitHubActionDigests": true,


### PR DESCRIPTION
## Summary

- Adds `baseBranchPatterns: ["$default"]` to the org-wide Renovate preset
- Explicitly targets each repo's default branch so Renovate never accidentally targets future release/staging branches
- Uses the current option name per Renovate schema v43.141.2 — `baseBranches` is the deprecated alias

## Changes

- `renovate-presets.json`: Added `"baseBranchPatterns": ["$default"]` after `platformAutomerge`

## Validation

Confirmed `baseBranchPatterns` is valid in the live Renovate schema:
```
curl -s https://docs.renovatebot.com/renovate-schema.json | jq '.properties.baseBranchPatterns'
# schema version: 43.141.2
```

Note: `npx renovate-config-validator` (old version) rejects this and pre-existing `pinGitHubActionDigests` — the npx-cached version is stale. The live schema is authoritative.

## Test Plan

- [x] CodeQL passes
- [x] CI passes
- [ ] Renovate bot next run produces no deprecation warnings about `baseBranches`

🤖 Generated with [Claude Code](https://claude.com/claude-code)