### PR TITLE
feat: add ignore-vulns input to _python-security workflow

### DIFF
--- a/.github/workflows/_python-security.yml
+++ b/.github/workflows/_python-security.yml
@@ -11,6 +11,15 @@ on:
         description: 'Space-separated list of directories containing pyproject.toml'
         required: true
         type: string
+      ignore-vulns:
+        description: |
+          Space-separated list of vulnerability IDs (GHSA / CVE / PYSEC) to
+          skip. Use only for transitive dependencies with no available
+          upstream fix; document the rationale and a tracking issue in the
+          calling repo. Each ID is passed to `pip-audit --ignore-vuln`.
+        required: false
+        type: string
+        default: ''
 
 concurrency:
   group: python-security-${{ github.workflow }}-${{ github.ref }}
@@ -29,17 +38,16 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v8.1.0
 
+      - name: Checkout central scripts
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ github.repository_owner }}/.github
+          path: .central-config
+          sparse-checkout: scripts/run-pip-audit.sh
+          sparse-checkout-cone-mode: false
+
       - name: Audit Python dependencies
         env:
           PYTHON_DIRS: ${{ inputs.python-dirs }}
-        run: |
-          for dir in $PYTHON_DIRS; do
-            echo "::group::Scanning $dir"
-            cd "$GITHUB_WORKSPACE/$dir"
-            # --no-emit-project avoids exporting the local project as an editable requirement when
-            # hashes are present, which would cause pip / pip-audit to fail with
-            # "editable requirement cannot be installed when requiring hashes".
-            uv export --format requirements-txt --output-file requirements.txt --locked --no-emit-project
-            uvx pip-audit --progress-spinner=off --desc -r requirements.txt
-            echo "::endgroup::"
-          done
+          IGNORE_VULNS: ${{ inputs.ignore-vulns }}
+        run: bash "$GITHUB_WORKSPACE/.central-config/scripts/run-pip-audit.sh"

--- a/scripts/run-pip-audit.sh
+++ b/scripts/run-pip-audit.sh
@@ -9,21 +9,23 @@
 # Used by: .github/workflows/_python-security.yml
 set -euo pipefail
 
-IGNORE_FLAGS=""
+ignore_args=()
 if [[ -n "${IGNORE_VULNS:-}" ]]; then
   for vuln in $IGNORE_VULNS; do
-    IGNORE_FLAGS+=" --ignore-vuln $vuln"
+    ignore_args+=(--ignore-vuln "$vuln")
   done
 fi
 
 for dir in $PYTHON_DIRS; do
-  echo "::group::Scanning $dir"
-  cd "$GITHUB_WORKSPACE/$dir"
-  # --no-emit-project avoids exporting the local project as an editable requirement when
-  # hashes are present, which would cause pip / pip-audit to fail with
-  # "editable requirement cannot be installed when requiring hashes".
-  uv export --format requirements-txt --output-file requirements.txt --locked --no-emit-project
-  # shellcheck disable=SC2086 # word splitting is intentional for IGNORE_FLAGS
-  uvx pip-audit --progress-spinner=off --desc $IGNORE_FLAGS -r requirements.txt
-  echo "::endgroup::"
+  (
+    echo "::group::Scanning $dir"
+    trap 'echo "::endgroup::"' EXIT
+    cd "$GITHUB_WORKSPACE/$dir"
+    # --no-emit-project avoids exporting the local project as an editable
+    # requirement when hashes are present, which would cause pip / pip-audit
+    # to fail with "editable requirement cannot be installed when requiring
+    # hashes".
+    uv export --format requirements-txt --output-file requirements.txt --locked --no-emit-project
+    uvx pip-audit --progress-spinner=off --desc "${ignore_args[@]}" -r requirements.txt
+  )
 done

--- a/scripts/run-pip-audit.sh
+++ b/scripts/run-pip-audit.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Run pip-audit against each project directory, optionally suppressing
+# specific vulnerability IDs (transitive deps with no upstream fix).
+#
+# Inputs (env):
+#   PYTHON_DIRS    space-separated project paths (relative to GITHUB_WORKSPACE)
+#   IGNORE_VULNS   space-separated CVE / GHSA / PYSEC IDs to skip (optional)
+#
+# Used by: .github/workflows/_python-security.yml
+set -euo pipefail
+
+IGNORE_FLAGS=""
+if [[ -n "${IGNORE_VULNS:-}" ]]; then
+  for vuln in $IGNORE_VULNS; do
+    IGNORE_FLAGS+=" --ignore-vuln $vuln"
+  done
+fi
+
+for dir in $PYTHON_DIRS; do
+  echo "::group::Scanning $dir"
+  cd "$GITHUB_WORKSPACE/$dir"
+  # --no-emit-project avoids exporting the local project as an editable requirement when
+  # hashes are present, which would cause pip / pip-audit to fail with
+  # "editable requirement cannot be installed when requiring hashes".
+  uv export --format requirements-txt --output-file requirements.txt --locked --no-emit-project
+  # shellcheck disable=SC2086 # word splitting is intentional for IGNORE_FLAGS
+  uvx pip-audit --progress-spinner=off --desc $IGNORE_FLAGS -r requirements.txt
+  echo "::endgroup::"
+done


### PR DESCRIPTION
## Summary

- Add an optional `ignore-vulns` input to the `_python-security.yml` reusable workflow. Each space-separated ID is passed to `pip-audit --ignore-vuln`.
- Extract audit logic to `scripts/run-pip-audit.sh` (workflow linter blocks complex inline bash). Fetched via sparse checkout from the same `.github` repo at runtime.

## Why

Calling repos can acknowledge specific transitive vulnerabilities with no upstream fix — narrow per-CVE acceptance, not blanket disable. Each ignored ID is documented in the calling repo's `ci-gate.yml` with a comment linking to a tracking issue.

Triggered by [JacobPEvans/mlx-benchmarks#19](https://github.com/JacobPEvans/mlx-benchmarks/pull/19): `lm-eval[api]==0.4.11` transitively depends on `sqlitedict 2.1.0` (GHSA-g4r7-86gm-pgqc / CVE-2024-35515), no upstream patch. CVE is local-deserialization; dep is in lm-eval's caching layer only.

## Behavior

- `ignore-vulns` is **optional**; existing callers continue to work unchanged.
- New findings always fail the build — only IDs in the explicit list are skipped.
- Ignored IDs should be documented in the calling repo with a tracking issue.

## Test plan

- [x] Workflow YAML syntax (actionlint)
- [ ] After merge: mlx-benchmarks#19 validates end-to-end