### PR TITLE
fix(markdown-lint): exclude CHANGELOG.md from lint globs

### DIFF
--- a/.github/workflows/_markdown-lint.yml
+++ b/.github/workflows/_markdown-lint.yml
@@ -32,4 +32,5 @@ jobs:
         with:
           globs: |
             **/*.md
+            !CHANGELOG.md
             !**/node_modules/**


### PR DESCRIPTION
## Summary

- Adds `!CHANGELOG.md` to the markdownlint glob patterns in `_markdown-lint.yml`

## Why

`release-please` generates CHANGELOG.md with long GitHub PR URLs (MD013 violations) and double blank lines between section headers (MD012 violations). This is by design and won't be fixed upstream ([googleapis/release-please#2085](https://github.com/googleapis/release-please/issues/2085), closed won't-fix).

`ignorePatterns` in the config and per-file `overrides` are not respected when the action passes explicit globs — a negative glob entry is the only reliable exclusion mechanism.

## Test Plan

- [ ] Verify `mlx-benchmarks` PR #24 (`chore(main): release 0.5.0`) CI passes after this merges

🤖 Generated with [Claude Code](https://claude.ai/claude-code)