### PR TITLE
fix(release-please): handle label-race gracefully with error guard

### DIFF
--- a/.github/workflows/_release-please.yml
+++ b/.github/workflows/_release-please.yml
@@ -72,8 +72,15 @@ jobs:
           permission-pull-requests: write
           permission-issues: write
 
+      # `continue-on-error` tolerates the upstream label-application race:
+      # release-please-action opens the PR successfully, then immediately tries
+      # to apply `autorelease: pending` via GraphQL — but the PR's global node ID
+      # hasn't propagated yet, so GitHub returns "Could not resolve to a node".
+      # The PR is still created and the downstream `Find release PR number` step
+      # discovers it via REST, so a label-only failure should not fail the job.
       - uses: googleapis/release-please-action@v5
         id: release
+        continue-on-error: true
         with:
           token: ${{ steps.app-token.outputs.token }}
           manifest-file: .release-please-manifest.json

--- a/.github/workflows/_release-please.yml
+++ b/.github/workflows/_release-please.yml
@@ -96,6 +96,12 @@ jobs:
           PR_NUMBER=$(gh pr list --head "release-please--branches--${BASE_BRANCH}" --json number --jq '.[0].number // empty')
           echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
 
+      - name: Re-fail on genuine release-please error
+        if: "!cancelled() && steps.release.outcome == 'failure' && steps.find-pr.outputs.number == ''"
+        run: |
+          echo "::error::release-please-action failed and no release PR was found via REST. This is a genuine failure (auth/config/API error), not a transient label-application race."
+          exit 1
+
       # Disable+re-enable handles RC3 (stale auto-merge queue: PR is CLEAN with
       # auto-merge enabled but GitHub never executes the merge). The retry loop
       # handles RC2 (transient GraphQL errors from `gh pr merge --auto`).


### PR DESCRIPTION
## Summary

Fixes a race condition where `googleapis/release-please-action@v5` fails with "Could not resolve to a node" when applying the `autorelease: pending` label immediately after PR creation (the PR's global node ID hasn't propagated yet). The fix tolerates the initial failure and adds a guard step that re-fails only on genuine errors (auth, config, API issues).

## Changes

- `.github/workflows/_release-please.yml`:
  - Add `continue-on-error: true` to the `googleapis/release-please-action@v5` step with explanatory comment
  - Add downstream guard step that re-fails when release-please errors AND the REST lookup finds no PR — catching genuine failures (auth/config/API) while silencing the cosmetic label-race
  - The existing `Find release PR number` step already discovers the PR via REST, so a label-only failure no longer fails the job

## Test Plan

- [ ] Trigger release-please on a consumer repo and confirm the job exits 0 even when the GraphQL `addLabel` call returns "Could not resolve to a node"
- [ ] Confirm the release PR is still created and downstream auto-merge still runs
- [ ] Verify that genuine auth/config/API errors still fail the workflow via the guard step (release-please errored AND no PR found via REST)

Closes #234