### PR TITLE
fix(pip-audit): run uv lock before export to handle version bumps

### DIFF
--- a/scripts/run-pip-audit.sh
+++ b/scripts/run-pip-audit.sh
@@ -21,6 +21,10 @@ for dir in $PYTHON_DIRS; do
     echo "::group::Scanning $dir"
     trap 'echo "::endgroup::"' EXIT
     cd "$GITHUB_WORKSPACE/$dir"
+    # Sync lock file in case pyproject.toml version was bumped (e.g. by
+    # release-please) without a corresponding `uv lock` run. This is a
+    # no-op when the lock file is already up to date.
+    uv lock
     # --no-emit-project avoids exporting the local project as an editable
     # requirement when hashes are present, which would cause pip / pip-audit
     # to fail with "editable requirement cannot be installed when requiring


### PR DESCRIPTION
## Summary

- Adds `uv lock` before `uv export --locked` in `run-pip-audit.sh`

## Why

`release-please` bumps the package version in `pyproject.toml` without running `uv lock`. The existing `uv export --locked` step then fails with:

```
error: The lockfile at `uv.lock` needs to be updated, but `--locked` was provided.
```

`uv lock` without `--upgrade` is a no-op when the lock file is already current — it only updates the local package's version metadata. This makes release-please PRs pass pip-audit without manual intervention.

## Test Plan

- [ ] `mlx-benchmarks` PR #24 (`chore(main): release 0.5.0`) pip-audit passes after this merges

🤖 Generated with [Claude Code](https://claude.ai/claude-code)