### PR TITLE
fix(renovate): bump lower-bound ranges on CVEs + simplify custom regex

### DIFF
--- a/renovate-presets.json
+++ b/renovate-presets.json
@@ -16,11 +16,17 @@
   ],
   "minimumReleaseAge": "3 days",
   "timezone": "America/Chicago",
+  "rangeStrategy": "update-lockfile",
+  "pep723": {
+    "managerFilePatterns": ["/\\.py$/"]
+  },
   "vulnerabilityAlerts": {
     "enabled": true,
     "labels": ["type:security"],
     "automerge": true,
-    "minimumReleaseAge": "0 days"
+    "minimumReleaseAge": "0 days",
+    "rangeStrategy": "bump",
+    "vulnerabilityFixStrategy": "highest"
   },
   "lockFileMaintenance": {
     "enabled": true,
@@ -42,8 +48,8 @@
       "customType": "regex",
       "fileMatch": ["\\.nix$"],
       "matchStrings": [
-        "\"(?<depName>@[a-zA-Z0-9-]+/[a-zA-Z0-9][a-zA-Z0-9._-]*)@(?<currentValue>[\\d][^\\s\"]*)\"",
-        "bunx\\s+--bun\\s+(?<depName>(?:@[^@/]+\\/)?[^@\\s]+)@(?<currentValue>[\\d][^\\s\"']*)"
+        "\"(?<depName>@[a-z0-9][a-z0-9-]*/[a-z0-9][a-z0-9._-]*)@(?<currentValue>\\d+(?:\\.\\d+)*(?:[._-]?(?:a|b|rc|alpha|beta|dev|post)\\d*)?(?:\\+[A-Za-z0-9.]+)?)\"",
+        "bunx\\s+--bun\\s+(?<depName>(?:@[^@/]+\\/)?[^@\\s]+)@(?<currentValue>\\d+(?:\\.\\d+)*(?:[._-]?(?:a|b|rc|alpha|beta|dev|post)\\d*)?(?:\\+[A-Za-z0-9.]+)?)"
       ],
       "datasourceTemplate": "npm"
     },
@@ -52,11 +58,7 @@
       "customType": "regex",
       "fileMatch": ["\\.nix$"],
       "matchStrings": [
-        "uvx\\s+--from\\s+\"(?<depName>[a-zA-Z0-9][a-zA-Z0-9._-]*)(?:\\[[^\\]]+\\])?==(?<currentValue>[\\d][^\\s\"]*)\"",
-        "uv\\s+run[^\"]*--with\\s+\"(?<depName>[a-zA-Z0-9][a-zA-Z0-9._-]*)(?:\\[[^\\]]+\\])?==(?<currentValue>[\\d][^\\s\"]*)\"",
-        "\"--from\"\\r?\\n\\s+\"(?<depName>[a-zA-Z0-9][a-zA-Z0-9._-]*)(?:\\[[^\\]]+\\])?==(?<currentValue>[\\d][^\\s\"]*)\"",
-        "\"--with\"\\r?\\n\\s+\"(?<depName>[a-zA-Z0-9][a-zA-Z0-9._-]*)(?:\\[[^\\]]+\\])?==(?<currentValue>[\\d][^\\s\"]*)\"",
-        "\\buv\\S*\\s+tool\\s+install\\s+\"(?<depName>[a-zA-Z0-9][a-zA-Z0-9._-]*)(?:\\[[^\\]]+\\])?==(?<currentValue>[\\d][^\\s\"]*)\""
+        "(?:uvx\\s+--from\\s+|uv\\s+run[^\"]*--with\\s+|\\buv\\S*\\s+tool\\s+install\\s+|\"--(?:from|with)\"\\r?\\n\\s+)\"(?<depName>[A-Za-z0-9][A-Za-z0-9._-]*)(?:\\[[^\\]]+\\])?==(?<currentValue>\\d+(?:\\.\\d+)*(?:[._-]?(?:a|b|rc|alpha|beta|dev|post)\\d*)?(?:\\+[A-Za-z0-9.]+)?)\""
       ],
       "datasourceTemplate": "pypi"
     },
@@ -65,7 +67,7 @@
       "customType": "regex",
       "fileMatch": ["\\.github/workflows/.*\\.ya?ml$"],
       "matchStrings": [
-        "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)[\\r\\n]+[\\s\\S]*?\\bnpx\\b\\s+(?:--yes\\s+|-y\\s+)?\\S+@(?<currentValue>[^\\s\"']+)"
+        "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)[\\r\\n]+[\\s\\S]*?\\bnpx\\b\\s+(?:--yes\\s+|-y\\s+)?\\S+@(?<currentValue>\\d+(?:\\.\\d+)*(?:[._-]?(?:a|b|rc|alpha|beta|dev|post)\\d*)?(?:\\+[A-Za-z0-9.]+)?)"
       ]
     }
   ],


### PR DESCRIPTION
## Summary

- Fix root cause of [mlx-benchmarks#28](https://github.com/JacobPEvans/mlx-benchmarks/pull/28): security PRs now widen `>=X` lower bounds (`rangeStrategy: bump` + `vulnerabilityFixStrategy: highest` inside `vulnerabilityAlerts`).
- Enable the built-in `pep723` manager so PEP 723 inline-metadata scripts get tracked org-wide (e.g. mlx-benchmarks `harness/framework-eval/eval_*.py`).
- Consolidate 5 uv/uvx custom-regex `matchStrings` into 1 (alternation in the trigger group). All 5 historical case shapes still match — verified locally.
- Replace imprecise version capture (`[\d][^\s\"]*`) across all custom managers with a PEP 440 / semver pattern.
- Tighten npm-in-Nix scope regex to npm spec lowercase.

Net diff: +11 / -9 lines, single file (`renovate-presets.json`).

## Why mlx-benchmarks#28 was manual

`vulnerabilityAlerts` defaults `rangeStrategy` to `update-lockfile`, which only edits committed lockfiles — never manifest ranges. mlx-benchmarks has no committed lockfile, and `pyarrow>=14` was *already satisfied by* the patched `17.0.0`, so Renovate considered the constraint up-to-date. Same for `pillow>=10.4.0`. A human had to widen the floor.

With this PR, future critical CVEs in inheriting repos auto-PR with the floor moved to latest. Existing \"never auto-merge majors\" rule is preserved — security-major bumps still land for human review.

## Test plan

- [x] All 5 regexes compile in JS (`new RegExp(...)`)
- [x] Consolidated uv/uvx pattern matches all 5 historical case shapes (`uvx --from`, `uv run --with`, `uv tool install`, multi-line `\"--from\"`/`\"--with\"`)
- [x] `renovate-config-validator --no-global` accepts new options (`pep723`, `vulnerabilityFixStrategy`, `rangeStrategy` overrides)
- [ ] After merge: confirm next mlx-benchmarks Renovate run surfaces `pyarrow` / `pillow` for re-bump (or that the existing PR #28 already covers them)
- [ ] After merge: confirm pep723 picks up `harness/framework-eval/eval_*.py` deps in mlx-benchmarks dependency dashboard

## Out of scope (follow-ups)

- 12 JacobPEvans repos with no Renovate config — separate onboarding issue
- `fileMatch` → `managerFilePatterns` migration (Renovate 41+ deprecation)
- nix-darwin Cribl Edge custom datasource — keep local (single-repo concern)
- Pre-existing `pinGitHubActionDigests` validation warning in Renovate 43.x — Mend's hosted runner accepts it, but worth confirming whether to switch to `pinDigests` or remove