### PR TITLE
feat(ci): auto-merge gh-aw pin-refresh PRs with 24h SHA soak

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -16,6 +16,7 @@
     "githubnext",
     "logstream",
     "signingkey",
+    "slurpfile",
     "wwwm",
     "xoxb"
   ],

--- a/.github/actions/gh-aw-soak-refresh/action.yml
+++ b/.github/actions/gh-aw-soak-refresh/action.yml
@@ -1,0 +1,18 @@
+name: gh-aw soaked pin refresh
+description: |
+  Refresh gh-aw action SHA pins with a 24-hour supply-chain soak.
+  Any newly-resolved SHA whose underlying commit is less than 24h old is
+  rewound to its predecessor SHA from the existing lock file, so the run
+  never adopts a freshly-released SHA without giving the world a day to
+  flag it.
+inputs:
+  github-token:
+    description: GitHub token with repo read access (used for commit-date lookups).
+    required: true
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+      run: ${{ github.action_path }}/refresh.sh

--- a/.github/actions/gh-aw-soak-refresh/diff-changed-pins.jq
+++ b/.github/actions/gh-aw-soak-refresh/diff-changed-pins.jq
@@ -1,0 +1,4 @@
+($b[0].entries // {}) as $o
+| .entries | to_entries[]
+| select(.value.sha != ($o[.key].sha // "") and ($o[.key].sha // "") != "")
+| "\(.key)|\(.value.repo | split("/") | .[0:2] | join("/"))|\(.value.sha)|\($o[.key].sha)"

--- a/.github/actions/gh-aw-soak-refresh/refresh.sh
+++ b/.github/actions/gh-aw-soak-refresh/refresh.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Refresh gh-aw action SHA pins with a 24h supply-chain soak.
+#
+# 1. Snapshot HEAD's lock file (the "before" state).
+# 2. Force-refresh all pins to current upstream SHAs.
+# 3. For each entry whose SHA changed AND the new SHA's commit is <24h
+#    old, rewind that entry's SHA to its predecessor in the lock file.
+#    The `version` field is left unchanged; the lock file stays consistent.
+# 4. Re-emit .lock.yml files via a no-flag `gh aw compile`.
+#
+# First-time pins (no predecessor in HEAD's lock file) skip the rewind
+# and adopt the fresh SHA -- recurring refreshes never encounter this.
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+LOCK=.github/aw/actions-lock.json
+BEFORE=$(mktemp)
+trap 'rm -f "$BEFORE"' EXIT
+
+git show "HEAD:$LOCK" >"$BEFORE" 2>/dev/null || echo '{"entries":{}}' >"$BEFORE"
+
+gh aw compile --force-refresh-action-pins
+
+NOW=$(date -u +%s)
+
+while IFS='|' read -r key repo new_sha old_sha; do
+  d=$(gh api "repos/$repo/commits/$new_sha" --jq .commit.committer.date 2>/dev/null) || continue
+  age_h=$(((NOW - $(date -d "$d" +%s)) / 3600))
+  if [ "$age_h" -lt 24 ]; then
+    tmp=$(mktemp)
+    jq --arg k "$key" --arg s "$old_sha" '.entries[$k].sha = $s' "$LOCK" >"$tmp"
+    mv "$tmp" "$LOCK"
+    echo "rewound: $key  $new_sha -> $old_sha  (commit was ${age_h}h old)"
+  fi
+done < <(jq -r --slurpfile b "$BEFORE" -f "$SCRIPT_DIR/diff-changed-pins.jq" "$LOCK")
+
+gh aw compile

--- a/.github/actions/gh-aw-soak-refresh/refresh.sh
+++ b/.github/actions/gh-aw-soak-refresh/refresh.sh
@@ -24,15 +24,27 @@ gh aw compile --force-refresh-action-pins
 
 NOW=$(date -u +%s)
 
+# Capture jq output up front so a jq failure aborts via `set -e`. A while-read
+# fed by `< <(jq ...)` would silently swallow jq's exit status and let the run
+# continue with no rewinds applied.
+CHANGED=$(jq -r --slurpfile b "$BEFORE" -f "$SCRIPT_DIR/diff-changed-pins.jq" "$LOCK")
+
 while IFS='|' read -r key repo new_sha old_sha; do
-  d=$(gh api "repos/$repo/commits/$new_sha" --jq .commit.committer.date 2>/dev/null) || continue
-  age_h=$(((NOW - $(date -d "$d" +%s)) / 3600))
+  # Fail closed: if the commit-date lookup fails (rate limit, transient network,
+  # SHA not yet visible), treat the entry as "too new" and rewind to the
+  # predecessor. Adopting an unverified fresh SHA would break the soak guarantee.
+  if d=$(gh api "repos/$repo/commits/$new_sha" --jq .commit.committer.date 2>/dev/null); then
+    age_h=$(((NOW - $(date -d "$d" +%s)) / 3600))
+  else
+    echo "warn: commit-date lookup failed for $repo@$new_sha; failing closed (rewind)"
+    age_h=0
+  fi
   if [ "$age_h" -lt 24 ]; then
     tmp=$(mktemp)
     jq --arg k "$key" --arg s "$old_sha" '.entries[$k].sha = $s' "$LOCK" >"$tmp"
     mv "$tmp" "$LOCK"
     echo "rewound: $key  $new_sha -> $old_sha  (commit was ${age_h}h old)"
   fi
-done < <(jq -r --slurpfile b "$BEFORE" -f "$SCRIPT_DIR/diff-changed-pins.jq" "$LOCK")
+done <<< "$CHANGED"
 
 gh aw compile

--- a/.github/workflows/_gh-aw-pin-refresh.yml
+++ b/.github/workflows/_gh-aw-pin-refresh.yml
@@ -70,18 +70,20 @@ jobs:
         with:
           version: v0.68.3
 
-      - name: Refresh action pins
+      - name: Run gh aw upgrade
+        if: inputs.operation == 'upgrade'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          GH_AW_OPERATION: ${{ inputs.operation }}
-        run: |
-          if [ "$GH_AW_OPERATION" = "upgrade" ]; then
-            gh aw upgrade
-          else
-            gh aw compile --force-refresh-action-pins
-          fi
+        run: gh aw upgrade
+
+      - name: Refresh action pins (with 24h supply-chain soak)
+        if: inputs.operation != 'upgrade'
+        uses: JacobPEvans/.github/.github/actions/gh-aw-soak-refresh@main
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
 
       - name: Create pull request
+        id: cpr
         uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ steps.app-token.outputs.token }}
@@ -94,5 +96,19 @@ jobs:
 
             Updates `actions-lock.json`, all `*.lock.yml` workflows, and
             `agentics-maintenance.yml` with consistent, freshly-resolved SHAs.
+            SHAs younger than 24h are held back to their predecessor (supply-chain soak).
           labels: dependencies
           commit-message: "fix(deps): refresh gh-aw action SHA pins"
+
+      # Disable+re-enable handles RC3 (stale auto-merge queue: PR is CLEAN
+      # with auto-merge enabled but GitHub never executes the merge). The
+      # retry loop handles RC2 (transient GraphQL errors from `gh pr merge --auto`).
+      - name: Enable auto-merge (with re-poke + retry)
+        if: "!cancelled() && steps.cpr.outputs.pull-request-number != ''"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
+        run: |
+          gh pr merge "$PR_NUMBER" --disable-auto 2>/dev/null || true
+          for _ in 1 2 3; do gh pr merge "$PR_NUMBER" --auto --squash && exit 0; sleep 15; done
+          exit 1


### PR DESCRIPTION
## Summary

The recurring `fix(deps): refresh gh-aw action SHA pins` PRs (created twice weekly by `_gh-aw-pin-refresh.yml`) sit open indefinitely after CI passes — `autoMergeRequest` is never set on them. Concrete examples right now: this repo's PR #255, and ai-assistant-instructions PR #605 (clean for ~2 days).

This PR closes that gap, with one extra constraint: never adopt a SHA whose underlying commit is less than 24 hours old.

## What changes

- **New composite action** `.github/actions/gh-aw-soak-refresh/` (`action.yml` + `refresh.sh` + `diff-changed-pins.jq`).
  Wraps `gh aw compile --force-refresh-action-pins`, then for any entry whose newly-resolved SHA's commit is <24h old, rewinds that entry's SHA to its predecessor in HEAD's lock file and re-emits `.lock.yml` files via a no-flag `gh aw compile`. The pin update is held back to "the version before that" — not a separate fail-the-run gate.
- **Workflow split** in `_gh-aw-pin-refresh.yml`: the inline `Refresh action pins` step is replaced with two declarative steps (one-liner for the `upgrade` path, composite-action call for the default `compile` path).
- **Auto-merge step** appended after `peter-evans/create-pull-request@v8`, mirroring the proven `_release-please.yml` pattern (disable+re-enable + retry loop to dodge GitHub auto-merge queue RC2/RC3 races).
- **cspell** dictionary picks up `slurpfile` (jq flag name).

## Why this shape

- **Reusable workflow → all repos inherit it.** `_gh-aw-pin-refresh.yml` is referenced as `@main` from every consumer repo; the composite action is loaded by full repo path so it works whether the workflow is invoked from `.github` itself or any consumer. No per-repo PRs needed.
- **Trust boundary already correct.** `gh aw compile` only resolves SHAs from refs the gh-aw CLI emits (sourced from `github/gh-aw-actions`, official GitHub org). The workflow itself is the matcher — no Renovate `matchPackageNames` filter required.
- **Soak baked into the resolution, not a fail-gate.** When every changed entry rewinds, the lock file ends up identical to HEAD, `gh aw compile` produces no diff, no PR is created, and the auto-merge step is skipped by its `if` guard. Clean no-op.

## Caveat

Brand-new action refs with no prior lock entry adopt the fresh SHA (no predecessor to rewind to). Only developer-initiated changes hit this path; the recurring twice-weekly refresh never does.

## Test plan

- [x] `pre-commit run --files <changed>` — all hooks pass (yaml, eof, trailing whitespace, cspell, file-size)
- [x] `shellcheck refresh.sh` — clean (jq extracted to `diff-changed-pins.jq` to avoid SC2016 entirely)
- [ ] After merge: `gh workflow run gh-aw-pin-refresh.yml --repo JacobPEvans/.github` and verify
  - `Refresh action pins (with 24h supply-chain soak)` step runs (composite action loads)
  - Either zero `rewound:` lines or a sensible set of rewinds
  - `Enable auto-merge` step prints a successful `gh pr merge ... --auto` (or skips if no PR was created)
  - The resulting PR (if any) auto-merges once CI completes
- [ ] Spot-check a consumer repo on the next Mon/Thu cron run
- [ ] Backfill: enable auto-merge on existing stale `gh-aw/refresh-action-pins` PRs across repos

Assisted-by: Claude <noreply@anthropic.com>