### PR TITLE
fix(soak): guard empty CHANGED to prevent bogus lock-file entry

### DIFF
--- a/.github/actions/gh-aw-soak-refresh/refresh.sh
+++ b/.github/actions/gh-aw-soak-refresh/refresh.sh
@@ -29,22 +29,28 @@ NOW=$(date -u +%s)
 # continue with no rewinds applied.
 CHANGED=$(jq -r --slurpfile b "$BEFORE" -f "$SCRIPT_DIR/diff-changed-pins.jq" "$LOCK")
 
-while IFS='|' read -r key repo new_sha old_sha; do
-  # Fail closed: if the commit-date lookup fails (rate limit, transient network,
-  # SHA not yet visible), treat the entry as "too new" and rewind to the
-  # predecessor. Adopting an unverified fresh SHA would break the soak guarantee.
-  if d=$(gh api "repos/$repo/commits/$new_sha" --jq .commit.committer.date 2>/dev/null); then
-    age_h=$(((NOW - $(date -d "$d" +%s)) / 3600))
-  else
-    echo "warn: commit-date lookup failed for $repo@$new_sha; failing closed (rewind)"
-    age_h=0
-  fi
-  if [ "$age_h" -lt 24 ]; then
-    tmp=$(mktemp)
-    jq --arg k "$key" --arg s "$old_sha" '.entries[$k].sha = $s' "$LOCK" >"$tmp"
-    mv "$tmp" "$LOCK"
-    echo "rewound: $key  $new_sha -> $old_sha  (commit was ${age_h}h old)"
-  fi
-done <<< "$CHANGED"
+# Skip the loop entirely when no entries changed. `<<<` always feeds a single
+# trailing newline, so an empty CHANGED would otherwise drive one iteration
+# with all fields empty -- the prior version of this script wrote a bogus
+# `"":{"sha":""}` entry into the lock file in exactly that case.
+if [ -n "$CHANGED" ]; then
+  while IFS='|' read -r key repo new_sha old_sha; do
+    # Fail closed: if the commit-date lookup fails (rate limit, transient network,
+    # SHA not yet visible), treat the entry as "too new" and rewind to the
+    # predecessor. Adopting an unverified fresh SHA would break the soak guarantee.
+    if d=$(gh api "repos/$repo/commits/$new_sha" --jq .commit.committer.date 2>/dev/null); then
+      age_h=$(((NOW - $(date -d "$d" +%s)) / 3600))
+    else
+      echo "warn: commit-date lookup failed for $repo@$new_sha; failing closed (rewind)"
+      age_h=0
+    fi
+    if [ "$age_h" -lt 24 ]; then
+      tmp=$(mktemp)
+      jq --arg k "$key" --arg s "$old_sha" '.entries[$k].sha = $s' "$LOCK" >"$tmp"
+      mv "$tmp" "$LOCK"
+      echo "rewound: $key  $new_sha -> $old_sha  (commit was ${age_h}h old)"
+    fi
+  done <<< "$CHANGED"
+fi
 
 gh aw compile

--- a/.github/aw/actions-lock.json
+++ b/.github/aw/actions-lock.json
@@ -44,9 +44,6 @@
       "repo": "github/gh-aw-actions/setup",
       "version": "v0.68.3",
       "sha": "ba90f2186d7ad780ec640f364005fa24e797b360"
-    },
-    "": {
-      "sha": ""
     }
   }
 }


### PR DESCRIPTION
## Summary

Bug fix to `gh-aw-soak-refresh` (introduced in #264, exposed by smoke-test run #265).

When `gh aw compile --force-refresh-action-pins` resolved no SHA changes against HEAD, the `CHANGED=\$(jq …)` capture returned empty. `<<<` always feeds a trailing newline, so the while loop ran one iteration with all four fields empty, hit the fail-closed branch (`gh api repos//commits/` failed), and wrote a literal `\"\":{\"sha\":\"\"}` entry into `actions-lock.json` via `jq '.entries[\"\"].sha = \"\"'`.

PR #265 merged that bogus entry into main before it could be caught.

## Changes

- **`refresh.sh`**: wrap the rewind loop in `if [ -n \"\$CHANGED\" ]; then … fi`. Empty diff now produces zero iterations.
- **`actions-lock.json`**: remove the bogus `\"\":{\"sha\":\"\"}` entry that #265 wrote into main.

The runtime-import SHA bump in `link-checker.lock.yml` from #265 is **not** reverted — that's a legitimate refresh result.

## Test plan

- [x] Manual repro: `CHANGED=\"\"` → 0 iterations; `CHANGED=\"a|b|c|d\"` → 1 iteration
- [x] Pre-commit clean (yaml, eof, trailing whitespace, cspell, file-size)
- [x] Shellcheck clean
- [ ] After merge: re-trigger `gh-aw-pin-refresh.yml` to confirm a no-change run produces no rewind log lines and no PR (clean no-op)

Related: #264 (introduced the bug), #265 (exposed it)

Assisted-by: Claude <noreply@anthropic.com>