### PR TITLE
fix: migrate central reusable workflows from app-id to client-id

### DIFF
--- a/.github/workflows/_gh-aw-pin-refresh.yml
+++ b/.github/workflows/_gh-aw-pin-refresh.yml
@@ -16,12 +16,13 @@
 #       with:
 #         operation: compile   # or 'upgrade' for full gh-aw infrastructure update
 #       secrets:
-#         GH_ACTION_JACOBPEVANS_APP_ID: ${{ secrets.GH_ACTION_JACOBPEVANS_APP_ID }}
 #         GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
 #
 # Secrets required:
-#   GH_ACTION_JACOBPEVANS_APP_ID  - GitHub App ID
-#   GH_APP_PRIVATE_KEY            - GitHub App private key
+#   GH_APP_PRIVATE_KEY   - GitHub App private key (repo-level secret, distributed by secrets-sync)
+#
+# Variables required (flow automatically from calling repo):
+#   GH_APP_CLIENT_ID     - GitHub App Client ID (non-sensitive, distributed by secrets-sync)
 #
 # The GitHub App token is required so the resulting PR triggers `pull_request`
 # workflows (e.g. CI gate, CodeQL). PRs created with GITHUB_TOKEN do NOT trigger them.
@@ -37,10 +38,10 @@ on:
         type: string
         default: 'compile'
     secrets:
-      GH_ACTION_JACOBPEVANS_APP_ID:
-        required: true
       GH_APP_PRIVATE_KEY:
         required: true
+      GH_ACTION_JACOBPEVANS_APP_ID:
+        required: false  # legacy — accepted for backward compat, removed in Phase 5a
 
 permissions: {}
 
@@ -55,7 +56,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.GH_ACTION_JACOBPEVANS_APP_ID }}
+          client-id: ${{ vars.GH_APP_CLIENT_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write

--- a/.github/workflows/_release-please.yml
+++ b/.github/workflows/_release-please.yml
@@ -22,7 +22,7 @@
 #
 # Org/repo prerequisites:
 #   Calling repos must grant `contents: write` and `pull-requests: write` in the caller job
-#   permissions block.
+#   permissions block. Calling repos must have `vars.GH_APP_CLIENT_ID` set (via secrets-sync).
 #
 # Repo files:
 #   .release-please-manifest.json  - REQUIRED: version manifest (e.g. {"." : "1.2.3"})
@@ -33,7 +33,11 @@
 #   GH_APP_ID  - GitHub App ID (org/repo configuration variable, not a secret)
 #
 # Secrets required:
-#   GH_APP_PRIVATE_KEY  - GitHub App private key
+#   GH_APP_PRIVATE_KEY   - GitHub App private key (repo-level secret, distributed by secrets-sync)
+#
+# Variables required (flow automatically from calling repo):
+#   GH_APP_CLIENT_ID     - GitHub App Client ID (non-sensitive, distributed by secrets-sync)
+#   GH_APP_ID            - GitHub App numeric ID (for bot email construction)
 #
 # The GitHub App token is required so release-please PRs trigger `pull_request`
 # workflows (e.g. CI Gate). PRs created with GITHUB_TOKEN do NOT trigger them.
@@ -52,6 +56,8 @@ on:
     secrets:
       GH_APP_PRIVATE_KEY:
         required: true
+      GH_ACTION_JACOBPEVANS_APP_ID:
+        required: false  # legacy — accepted for backward compat, removed in Phase 5a
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -81,7 +87,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.GH_APP_ID }}
+          client-id: ${{ vars.GH_APP_CLIENT_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write

--- a/.github/workflows/_retrigger-pr-checks.yml
+++ b/.github/workflows/_retrigger-pr-checks.yml
@@ -21,10 +21,10 @@ name: _retrigger-pr-checks
 on:
   workflow_call:
     secrets:
-      GH_ACTION_JACOBPEVANS_APP_ID:
-        required: true
       GH_APP_PRIVATE_KEY:
         required: true
+      GH_ACTION_JACOBPEVANS_APP_ID:
+        required: false  # legacy — accepted for backward compat, removed in Phase 5a
 
 permissions: {}
 
@@ -41,7 +41,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.GH_ACTION_JACOBPEVANS_APP_ID }}
+          client-id: ${{ vars.GH_APP_CLIENT_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permission-pull-requests: write
 


### PR DESCRIPTION
## Summary
- Replaces deprecated `app-id:` with `client-id: ${{ vars.GH_APP_CLIENT_ID }}` on all three central reusable workflows (_release-please.yml, _gh-aw-pin-refresh.yml, _retrigger-pr-checks.yml)
- Uses non-sensitive variable `GH_APP_CLIENT_ID` distributed by secrets-sync — no secrets block change needed
- Keeps `GH_ACTION_JACOBPEVANS_APP_ID` as `required: false` in workflow_call.secrets for backward compatibility during consumer migration

**Merge order (CRITICAL):** secrets-sync#74 (merges first) → **this PR (merges second)** → consumer PRs

## Changes
- .github/workflows/_release-please.yml
- .github/workflows/_gh-aw-pin-refresh.yml
- .github/workflows/_retrigger-pr-checks.yml

## Test Plan
- [ ] secrets-sync#74 merged and Sync Secrets workflow completed (confirms GH_APP_CLIENT_ID distributed to all repos)
- [ ] After merging this PR: trigger release-please on ansible-proxmox — confirm no deprecation warnings in action logs
- [ ] Verify grep -n "app-id:" .github/workflows/_*.yml returns empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)