### PR TITLE
feat(release): add quiet-window auto-merge reusable workflow

### DIFF
--- a/.github/scripts/release-please-auto-merge.sh
+++ b/.github/scripts/release-please-auto-merge.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Enables auto-merge on the open release-please Release PR once it has
+# been idle (no new commits) for at least QUIET_SECONDS seconds.
+#
+# Required env vars (set by the calling workflow step's env: block):
+#   GH_TOKEN        - GitHub token with contents:write + pull-requests:write
+#   GITHUB_REPOSITORY - owner/repo of the target repository
+#   BASE_BRANCH     - base branch whose release PR to check
+#   QUIET_SECONDS   - minimum idle seconds before enabling auto-merge
+#   MERGE_METHOD    - squash | merge | rebase
+set -euo pipefail
+
+case "$MERGE_METHOD" in
+  squash|merge|rebase) ;;
+  *) echo "Invalid merge-method: $MERGE_METHOD"; exit 1 ;;
+esac
+
+PR=$(gh pr list \
+  --repo "$GITHUB_REPOSITORY" \
+  --head "release-please--branches--${BASE_BRANCH}" \
+  --state open \
+  --json number,updatedAt,labels \
+  --jq '.[0] // empty')
+
+[ -z "$PR" ] && { echo "No open release PR found."; exit 0; }
+
+PR_NUMBER=$(echo "$PR" | jq -r '.number')
+UPDATED_AT=$(echo "$PR" | jq -r '.updatedAt')
+
+if echo "$PR" | jq -e '.labels[].name | select(. == "do-not-merge" or . == "hold")' > /dev/null 2>&1; then
+  echo "Release PR #${PR_NUMBER} has a hold label -- skipping."
+  exit 0
+fi
+
+NOW=$(date +%s)
+UPDATED=$(date -d "$UPDATED_AT" +%s 2>/dev/null || date -j -f "%Y-%m-%dT%H:%M:%SZ" "$UPDATED_AT" +%s)
+IDLE=$(( NOW - UPDATED ))
+
+echo "Release PR #${PR_NUMBER} idle for ${IDLE}s (threshold: ${QUIET_SECONDS}s)."
+[ "$IDLE" -lt "$QUIET_SECONDS" ] && { echo "Not quiet yet -- skipping."; exit 0; }
+
+# Disable+re-enable handles stale auto-merge queue (RC3).
+# Retry loop handles transient GraphQL errors (RC2).
+gh pr merge "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --disable-auto 2>/dev/null || true
+for _ in 1 2 3; do
+  gh pr merge "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --auto "--${MERGE_METHOD}" && exit 0
+  sleep 15
+done
+exit 1

--- a/.github/workflows/_release-please-auto-merge.yml
+++ b/.github/workflows/_release-please-auto-merge.yml
@@ -49,9 +49,11 @@ on:
         type: string
         default: squash
       base-branch:
-        description: Base branch to check for an open release PR.
+        description: >
+          Base branch to check for an open release PR. Leave empty (default)
+          to use the repository's default branch.
         type: string
-        default: ${{ github.event.repository.default_branch }}
+        default: ''
     secrets:
       GH_APP_PRIVATE_KEY:
         required: true
@@ -81,8 +83,8 @@ jobs:
       - name: Check release PR idle time and enable auto-merge
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          BASE_BRANCH: ${{ inputs.base-branch }}
-          QUIET_SECONDS: ${{ fromJSON(inputs.quiet-minutes) * 60 }}
+          BASE_BRANCH: ${{ inputs.base-branch || github.event.repository.default_branch }}
+          QUIET_SECONDS: ${{ inputs.quiet-minutes * 60 }}
           MERGE_METHOD: ${{ inputs.merge-method }}
         run: |
           case "$MERGE_METHOD" in

--- a/.github/workflows/_release-please-auto-merge.yml
+++ b/.github/workflows/_release-please-auto-merge.yml
@@ -80,47 +80,16 @@ jobs:
           permission-contents: write
           permission-pull-requests: write
 
+      - uses: actions/checkout@v6
+        with:
+          repository: JacobPEvans/.github
+          ref: main
+          path: .dot-github
+
       - name: Check release PR idle time and enable auto-merge
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           BASE_BRANCH: ${{ inputs.base-branch || github.event.repository.default_branch }}
           QUIET_SECONDS: ${{ inputs.quiet-minutes * 60 }}
           MERGE_METHOD: ${{ inputs.merge-method }}
-        run: |
-          case "$MERGE_METHOD" in
-            squash|merge|rebase) ;;
-            *) echo "Invalid merge-method: $MERGE_METHOD"; exit 1 ;;
-          esac
-
-          PR=$(gh pr list \
-            --repo "$GITHUB_REPOSITORY" \
-            --head "release-please--branches--${BASE_BRANCH}" \
-            --state open \
-            --json number,updatedAt,labels \
-            --jq '.[0] // empty')
-
-          [ -z "$PR" ] && { echo "No open release PR found."; exit 0; }
-
-          PR_NUMBER=$(echo "$PR" | jq -r '.number')
-          UPDATED_AT=$(echo "$PR" | jq -r '.updatedAt')
-
-          if echo "$PR" | jq -e '.labels[].name | select(. == "do-not-merge" or . == "hold")' > /dev/null 2>&1; then
-            echo "Release PR #${PR_NUMBER} has a hold label -- skipping."
-            exit 0
-          fi
-
-          NOW=$(date +%s)
-          UPDATED=$(date -d "$UPDATED_AT" +%s 2>/dev/null || date -j -f "%Y-%m-%dT%H:%M:%SZ" "$UPDATED_AT" +%s)
-          IDLE=$(( NOW - UPDATED ))
-
-          echo "Release PR #${PR_NUMBER} idle for ${IDLE}s (threshold: ${QUIET_SECONDS}s)."
-          [ "$IDLE" -lt "$QUIET_SECONDS" ] && { echo "Not quiet yet -- skipping."; exit 0; }
-
-          # Disable+re-enable handles stale auto-merge queue (RC3).
-          # Retry loop handles transient GraphQL errors (RC2).
-          gh pr merge "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --disable-auto 2>/dev/null || true
-          for _ in 1 2 3; do
-            gh pr merge "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --auto "--${MERGE_METHOD}" && exit 0
-            sleep 15
-          done
-          exit 1
+        run: .dot-github/.github/scripts/release-please-auto-merge.sh

--- a/.github/workflows/_release-please-auto-merge.yml
+++ b/.github/workflows/_release-please-auto-merge.yml
@@ -1,0 +1,124 @@
+# Reusable: Release Please — Quiet-Window Auto-Merge
+#
+# Merges the open release-please Release PR only after it has been idle
+# (no new commits) for a configurable number of minutes. Run this on a
+# cron schedule so that a burst of near-simultaneous PRs all land in the
+# same release rather than triggering back-to-back releases.
+#
+# Typical caller (add to each repo that opts into quiet-window releases):
+#
+#   name: release-please-auto-merge
+#   on:
+#     schedule:
+#       - cron: '*/15 * * * *'
+#     workflow_dispatch:
+#   permissions: {}
+#   jobs:
+#     merge:
+#       permissions:
+#         contents: write
+#         pull-requests: write
+#       uses: JacobPEvans/.github/.github/workflows/_release-please-auto-merge.yml@main
+#       with:
+#         quiet-minutes: 10
+#       secrets:
+#         GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
+#
+#   In the same repo, also set auto-merge: false on the _release-please.yml
+#   caller so the two workflows don't race.
+#
+# Variables required:
+#   GH_APP_ID  - GitHub App ID (org/repo configuration variable, not a secret)
+#
+# Secrets required:
+#   GH_APP_PRIVATE_KEY  - GitHub App private key
+#
+# Note: GitHub cron scheduling can drift 5-15 min under platform load.
+# A quiet-minutes: 10 window may effectively become 10-25 min end-to-end.
+name: _release-please-auto-merge
+
+on:
+  workflow_call:
+    inputs:
+      quiet-minutes:
+        description: Minimum idle minutes before merging the release PR.
+        type: number
+        default: 10
+      merge-method:
+        description: Merge method passed to `gh pr merge` (squash, merge, rebase).
+        type: string
+        default: squash
+      base-branch:
+        description: Base branch to check for an open release PR.
+        type: string
+        default: ${{ github.event.repository.default_branch }}
+    secrets:
+      GH_APP_PRIVATE_KEY:
+        required: true
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Check release PR idle time and enable auto-merge
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          BASE_BRANCH: ${{ inputs.base-branch }}
+          QUIET_SECONDS: ${{ fromJSON(inputs.quiet-minutes) * 60 }}
+          MERGE_METHOD: ${{ inputs.merge-method }}
+        run: |
+          case "$MERGE_METHOD" in
+            squash|merge|rebase) ;;
+            *) echo "Invalid merge-method: $MERGE_METHOD"; exit 1 ;;
+          esac
+
+          PR=$(gh pr list \
+            --repo "$GITHUB_REPOSITORY" \
+            --head "release-please--branches--${BASE_BRANCH}" \
+            --state open \
+            --json number,updatedAt,labels \
+            --jq '.[0] // empty')
+
+          [ -z "$PR" ] && { echo "No open release PR found."; exit 0; }
+
+          PR_NUMBER=$(echo "$PR" | jq -r '.number')
+          UPDATED_AT=$(echo "$PR" | jq -r '.updatedAt')
+
+          if echo "$PR" | jq -e '.labels[].name | select(. == "do-not-merge" or . == "hold")' > /dev/null 2>&1; then
+            echo "Release PR #${PR_NUMBER} has a hold label -- skipping."
+            exit 0
+          fi
+
+          NOW=$(date +%s)
+          UPDATED=$(date -d "$UPDATED_AT" +%s 2>/dev/null || date -j -f "%Y-%m-%dT%H:%M:%SZ" "$UPDATED_AT" +%s)
+          IDLE=$(( NOW - UPDATED ))
+
+          echo "Release PR #${PR_NUMBER} idle for ${IDLE}s (threshold: ${QUIET_SECONDS}s)."
+          [ "$IDLE" -lt "$QUIET_SECONDS" ] && { echo "Not quiet yet -- skipping."; exit 0; }
+
+          # Disable+re-enable handles stale auto-merge queue (RC3).
+          # Retry loop handles transient GraphQL errors (RC2).
+          gh pr merge "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --disable-auto 2>/dev/null || true
+          for _ in 1 2 3; do
+            gh pr merge "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --auto "--${MERGE_METHOD}" && exit 0
+            sleep 15
+          done
+          exit 1

--- a/.github/workflows/_release-please.yml
+++ b/.github/workflows/_release-please.yml
@@ -10,21 +10,30 @@
 #         contents: write
 #         pull-requests: write
 #       uses: JacobPEvans/.github/.github/workflows/_release-please.yml@main
+#       with:
+#         auto-merge: true   # default; set false to use the quiet-window cron instead
 #       secrets:
-#         GH_ACTION_JACOBPEVANS_APP_ID: ${{ secrets.GH_ACTION_JACOBPEVANS_APP_ID }}
 #         GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
 #
+# Quiet-window alternative (batch multiple PRs into one release):
+#   Set auto-merge: false here, then add a separate caller that runs on a
+#   cron schedule and calls _release-please-auto-merge.yml@main.
+#   See _release-please-auto-merge.yml for the opt-in shape.
+#
 # Org/repo prerequisites:
-#   Calling repos must grant `contents: write` and `pull-requests: write` in the caller job permissions
+#   Calling repos must grant `contents: write` and `pull-requests: write` in the caller job
+#   permissions block.
 #
 # Repo files:
 #   .release-please-manifest.json  - REQUIRED: version manifest (e.g. {"." : "1.2.3"})
 #   release-please-config.json     - REQUIRED: release config (repo-specific settings only;
 #                                    versioning policy is enforced by this workflow centrally)
 #
+# Variables required:
+#   GH_APP_ID  - GitHub App ID (org/repo configuration variable, not a secret)
+#
 # Secrets required:
-#   GH_ACTION_JACOBPEVANS_APP_ID  - GitHub App ID (repo-level secret)
-#   GH_APP_PRIVATE_KEY            - GitHub App private key (repo-level secret)
+#   GH_APP_PRIVATE_KEY  - GitHub App private key
 #
 # The GitHub App token is required so release-please PRs trigger `pull_request`
 # workflows (e.g. CI Gate). PRs created with GITHUB_TOKEN do NOT trigger them.
@@ -32,9 +41,15 @@ name: _release-please
 
 on:
   workflow_call:
+    inputs:
+      auto-merge:
+        description: >
+          Enable eager auto-merge of the release PR as soon as checks pass.
+          Set to false and add the _release-please-auto-merge.yml cron caller
+          to use the quiet-window batching flow instead.
+        type: boolean
+        default: true
     secrets:
-      GH_ACTION_JACOBPEVANS_APP_ID:
-        required: true
       GH_APP_PRIVATE_KEY:
         required: true
 
@@ -66,7 +81,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.GH_ACTION_JACOBPEVANS_APP_ID }}
+          app-id: ${{ vars.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write
@@ -94,7 +109,7 @@ jobs:
       # handles RC2 (transient GraphQL errors from `gh pr merge --auto`).
       # Bot approval was removed earlier (github/community#162623).
       - name: Enable auto-merge for release PR (with re-poke + retry)
-        if: "!cancelled() && steps.find-pr.outputs.number != ''"
+        if: "!cancelled() && inputs.auto-merge && steps.find-pr.outputs.number != ''"
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ steps.find-pr.outputs.number }}


### PR DESCRIPTION
## Summary

- Adds `_release-please-auto-merge.yml`: cron-driven reusable workflow that
  enables auto-merge on the release PR only after a configurable quiet-window
  (default 10 min). Bursts of near-simultaneous PRs batch into one release
  instead of triggering back-to-back releases.
- Extends `_release-please.yml` with an `auto-merge: boolean` input
  (default `true` — fully backward-compatible) so callers can opt into the
  quiet-window flow by passing `auto-merge: false`.
- Migrates app-id lookup from `secrets.GH_ACTION_JACOBPEVANS_APP_ID` →
  `vars.GH_APP_ID` (configuration variable, no longer a secret).

## Changes

- `.github/workflows/_release-please.yml`: add `auto-merge` input, guard
  the auto-merge step, swap secret → config variable for App ID
- `.github/workflows/_release-please-auto-merge.yml` (new): quiet-window
  cron workflow; checks out `JacobPEvans/.github` to get the shared script,
  then delegates to it with env vars
- `.github/scripts/release-please-auto-merge.sh` (new): shell logic for
  idle-time check and auto-merge with disable+re-enable+retry pattern

## Breaking change note

Callers that pass `GH_ACTION_JACOBPEVANS_APP_ID:` as a secret will need to
drop that line. The App ID is now read from `vars.GH_APP_ID` directly
inside the reusable workflow — no caller wiring needed.

The same secret→var migration is needed in `_gh-aw-pin-refresh.yml` and
`_retrigger-pr-checks.yml` — tracked as a follow-up.

## How to opt in (per-repo, future PR)

1. Pass `auto-merge: false` on the existing `_release-please.yml` caller.
2. Add a new `release-please-auto-merge.yml` caller:

```yaml
name: release-please-auto-merge
on:
  schedule:
    - cron: '*/15 * * * *'
  workflow_dispatch:
permissions: {}
jobs:
  merge:
    permissions:
      contents: write
      pull-requests: write
    uses: JacobPEvans/.github/.github/workflows/_release-please-auto-merge.yml@main
    with:
      quiet-minutes: 10
    secrets:
      GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
```

## Test plan

- [ ] CI/lint passes on all three files
- [ ] Manually dispatch `_release-please-auto-merge.yml` against a repo
      with a release PR whose `updatedAt` is < 10 min ago → should log
      idle time and skip
- [ ] Same dispatch after idle > 10 min → should enable auto-merge
- [ ] Existing eager-merge consumers unaffected (no `auto-merge` input →
      defaults to `true`)

Related: #268

🤖 Generated with [Claude Code](https://claude.com/claude-code)