### PR TITLE
fix(renovate): eliminate custom managers; use annotations and native pep723

### DIFF
--- a/.github/workflows/_file-size.yml
+++ b/.github/workflows/_file-size.yml
@@ -70,7 +70,7 @@ jobs:
 
           errors=0 warnings=0
           while IFS= read -r -d '' f; do
-            base=$(basename "$f" | sed 's/\.[^.]*$//')
+            base="${f##*/}"; base="${base%.*}"
             size=$(stat -c%s "$f")
 
             # Skip exempt files

--- a/renovate-presets.json
+++ b/renovate-presets.json
@@ -20,7 +20,9 @@
     "enabled": true,
     "labels": ["type:security"],
     "automerge": true,
-    "minimumReleaseAge": "0 days"
+    "minimumReleaseAge": "0 days",
+    "rangeStrategy": "bump",
+    "vulnerabilityFixStrategy": "highest"
   },
   "lockFileMaintenance": {
     "enabled": true,
@@ -30,45 +32,18 @@
   },
   "customManagers": [
     {
-      "description": "Nix version pins annotated with renovate comments",
+      "description": "Renovate-annotated version pins in Nix files",
       "customType": "regex",
-      "fileMatch": ["\\.nix$"],
+      "managerFilePatterns": ["/\\.nix$/"],
       "matchStrings": [
-        "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)\\r?\\n\\s*\\S+\\s*=\\s*\"(?<currentValue>[^\"]+)\";"
-      ]
-    },
-    {
-      "description": "npm packages pinned in Nix string literals (bunx wrappers, MCP server args)",
-      "customType": "regex",
-      "fileMatch": ["\\.nix$"],
-      "matchStrings": [
-        "\"(?<depName>@[a-zA-Z0-9-]+/[a-zA-Z0-9][a-zA-Z0-9._-]*)@(?<currentValue>[\\d][^\\s\"]*)\"",
-        "bunx\\s+--bun\\s+(?<depName>(?:@[^@/]+\\/)?[^@\\s]+)@(?<currentValue>[\\d][^\\s\"']*)"
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: versioning=(?<versioning>\\S+))?\\s+\\S+\\s*=\\s*\"(?<currentValue>[^\"]+)\""
       ],
-      "datasourceTemplate": "npm"
-    },
-    {
-      "description": "uv/uvx PyPI packages pinned in Nix modules",
-      "customType": "regex",
-      "fileMatch": ["\\.nix$"],
-      "matchStrings": [
-        "uvx\\s+--from\\s+\"(?<depName>[a-zA-Z0-9][a-zA-Z0-9._-]*)(?:\\[[^\\]]+\\])?==(?<currentValue>[\\d][^\\s\"]*)\"",
-        "uv\\s+run[^\"]*--with\\s+\"(?<depName>[a-zA-Z0-9][a-zA-Z0-9._-]*)(?:\\[[^\\]]+\\])?==(?<currentValue>[\\d][^\\s\"]*)\"",
-        "\"--from\"\\r?\\n\\s+\"(?<depName>[a-zA-Z0-9][a-zA-Z0-9._-]*)(?:\\[[^\\]]+\\])?==(?<currentValue>[\\d][^\\s\"]*)\"",
-        "\"--with\"\\r?\\n\\s+\"(?<depName>[a-zA-Z0-9][a-zA-Z0-9._-]*)(?:\\[[^\\]]+\\])?==(?<currentValue>[\\d][^\\s\"]*)\"",
-        "\\buv\\S*\\s+tool\\s+install\\s+\"(?<depName>[a-zA-Z0-9][a-zA-Z0-9._-]*)(?:\\[[^\\]]+\\])?==(?<currentValue>[\\d][^\\s\"]*)\""
-      ],
-      "datasourceTemplate": "pypi"
-    },
-    {
-      "description": "npx version pins in GitHub Actions workflows annotated with renovate comments",
-      "customType": "regex",
-      "fileMatch": ["\\.github/workflows/.*\\.ya?ml$"],
-      "matchStrings": [
-        "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)[\\r\\n]+[\\s\\S]*?\\bnpx\\b\\s+(?:--yes\\s+|-y\\s+)?\\S+@(?<currentValue>[^\\s\"']+)"
-      ]
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver-coerced{{/if}}"
     }
   ],
+  "pep723": {
+    "managerFilePatterns": ["/\\.py$/"]
+  },
   "packageRules": [
     {
       "description": "Disable all updates in gh-aw generated files — managed by gh-aw-pin-refresh workflow, not Renovate",


### PR DESCRIPTION
## Summary

- Removes 3 of 4 custom-manager entries (npm-in-Nix, uv/uvx-in-Nix, npx-in-workflows), replacing with native Renovate managers
- Enables `pep723` manager org-wide for Python projects + scripts
- Migrates from inline pins to annotated let-vars (depends on nix-ai#702)

## Changes

### `.github/renovate.json`

- Delete custom manager: `npm-in-Nix` (2 patterns)
- Delete custom manager: `uv-uvx-in-Nix` (5 patterns) 
- Delete custom manager: `npx-in-workflows` (dead code, 0 matches)
- Simplify annotation manager to 1 `matchString` with `versioningTemplate`
- Migrate `fileMatch` → `managerFilePatterns` (Renovate 41+ required rename)
- Add `pep723: { enabled: true }` to preset
- Add `vulnerabilityAlerts: { rangeStrategy: bump, vulnerabilityFixStrategy: highest }`

### `.github/workflows/_file-size.yml`

- Replace sed subshell with bash parameter expansion for clarity

## Test Plan

- [ ] Verify renovate config syntax: `npx renovate --print-config > /dev/null`
- [ ] Check no CI regressions on nix-ai once nix-ai#702 merges
- [ ] Confirm pep723 manager picks up Python projects on next Renovate run
- [ ] Spot-check annotation matches in configured repos via Renovate dashboard

## Dependencies

Depends-on: nix-ai#702 (hoists 25 inline pins to annotated let-vars)

Closes #248 #263