### PR TITLE
ci: catch cross-platform broken packages via nix flake check --all-systems

### DIFF
--- a/.github/workflows/_nix-validate.yml
+++ b/.github/workflows/_nix-validate.yml
@@ -1,5 +1,6 @@
-# Reusable: Nix Validate (Linux)
-# Runs nix flake check with CI-optimized Nix settings and store caching.
+# Reusable: Nix Validate
+# Runs nix flake check --all-systems to catch broken packages on all declared
+# systems (darwin included) from a linux runner before they merge.
 name: _nix-validate
 
 on:
@@ -60,7 +61,7 @@ jobs:
             nix-linux-${{ runner.os }}-
 
       - name: Check flake
-        run: nix flake check --print-build-logs
+        run: nix flake check --all-systems --print-build-logs
 
       - name: Save Nix Store Cache
         if: github.event_name == 'push' && steps.nix-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
## Summary

- `nix flake check` previously evaluated only `checks.x86_64-linux` on `ubuntu-latest`
- darwin-scoped `meta.broken = true` flags passed CI undetected and merged (root cause of nix-home #229)
- `--all-systems` evaluates all 4 declared systems (both darwin + both linux arches) from the same linux runner
- No new runner needed — built-in Nix 2.18+ flag, zero infrastructure change

## Changes

- `.github/workflows/_nix-validate.yml`: add `--all-systems` to `nix flake check`, update header comment

## Test Plan

- [x] CI passes on this PR (CodeQL SUCCESS, Analyze SUCCESS)
- [ ] Verify nix-home PR #229 CI log shows all 4 systems evaluated after this merges