### PR TITLE
fix(ci): improve nix flake check diagnostic output

### DIFF
--- a/.github/workflows/_nix-validate.yml
+++ b/.github/workflows/_nix-validate.yml
@@ -48,6 +48,8 @@ jobs:
             stalled-download-timeout = 10
             narinfo-cache-positive-ttl = 86400
             fallback = true
+            show-trace = true
+            log-lines = 1000
 
       - name: Restore Nix Store Cache
         uses: actions/cache/restore@v5
@@ -61,7 +63,7 @@ jobs:
             nix-linux-${{ runner.os }}-
 
       - name: Check flake
-        run: nix flake check --all-systems --print-build-logs
+        run: nix flake check --all-systems --print-build-logs --show-trace --keep-going
 
       - name: Save Nix Store Cache
         if: github.event_name == 'push' && steps.nix-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/_nix-validate.yml
+++ b/.github/workflows/_nix-validate.yml
@@ -48,7 +48,6 @@ jobs:
             stalled-download-timeout = 10
             narinfo-cache-positive-ttl = 86400
             fallback = true
-            show-trace = true
             log-lines = 1000
 
       - name: Restore Nix Store Cache


### PR DESCRIPTION
## Summary

- Add `--show-trace` and `--keep-going` flags to `nix flake check` in `_nix-validate.yml`
- Add `log-lines = 1000` to the Nix `extra-conf` block (Nix's default is 25 lines)

`show-trace` is passed as a CLI flag only; the redundant `extra-conf` form was removed per review feedback. `log-lines` has no CLI equivalent, so it stays in `extra-conf`.

`--keep-going` preserves failure semantics: Nix still exits non-zero when any check fails and the merge gate blocks as before. The flag only affects how much is reported before that exit — all failing systems surface in one run instead of stopping at the first.

All inheriting repos (nix-home, nix-darwin, nix-ai) call this workflow with no overrides beyond `runner_label`, so they pick this up automatically on merge with no changes on their end.

## Changes

- `.github/workflows/_nix-validate.yml`: add `--show-trace --keep-going` to the `nix flake check` invocation; add `log-lines = 1000` to `extra-conf`

## Test plan

- [ ] Verify the Actions log on a nix-* PR after merge shows full stack traces on any eval error
- [ ] Confirm a broken flake still fails the CI gate (no silent pass)
- [ ] Confirm all failing systems are reported in a single run rather than stopping at the first failure