### PR TITLE
fix(ci): add --no-build to nix flake check --all-systems

### DIFF
--- a/.github/workflows/_nix-validate.yml
+++ b/.github/workflows/_nix-validate.yml
@@ -62,7 +62,12 @@ jobs:
             nix-linux-${{ runner.os }}-
 
       - name: Check flake
-        run: nix flake check --all-systems --print-build-logs --show-trace --keep-going
+        # --no-build: evaluate all systems' outputs without downloading/building
+        # derivations. Catches broken-package and evaluation errors cross-platform
+        # without exhausting disk on the linux runner (darwin packages like
+        # rustc-src, cctools, apple-sdk would otherwise be downloaded) or hitting
+        # "platform mismatch" build failures on aarch64-darwin-only derivations.
+        run: nix flake check --all-systems --no-build --print-build-logs --show-trace --keep-going
 
       - name: Save Nix Store Cache
         if: github.event_name == 'push' && steps.nix-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
## Summary
- Add `--no-build` to `nix flake check --all-systems` in `_nix-validate.yml`
- Preserves cross-platform broken-package detection from #294 but stops the linux runner from downloading multi-GB darwin packages or attempting to build aarch64-darwin-only derivations

## Why
After #294 added `--all-systems`, consuming repos started failing:
- **nix-darwin**: `error: write of 65536 bytes: No space left on device` while downloading rustc-src, cctools, apple-sdk for the darwin evaluation
- **nix-ai**: `Cannot build … Reason: platform mismatch / Required system: aarch64-darwin / Current system: x86_64-linux` for `wrap-claude-command-*` and similar derivations
- **nix-home**: arrow-cpp `meta.broken = true` on darwin (a real bug worth catching — fixed separately in nix-home repo)

`--no-build` keeps the evaluation step (which is where `meta.broken` is enforced and where syntax/type errors are caught), but skips the actual download + build. This is the standard pattern from `nixpkgs/.github/workflows`.

## Test plan
- [ ] After merge, re-run CI on \`nix-darwin/feature/add-firefox\` (#1091) — Nix Validate should pass
- [ ] Re-run CI on nix-ai open PRs (renovate/lock-file-maintenance, renovate/huggingface-hub-1.x) — Nix Validate should pass
- [ ] nix-home will still fail on arrow-cpp until its own PR lands (allowBroken fix in lib/checks.nix)

Assisted-by: Claude <noreply@anthropic.com>