### PR TITLE
fix(ci): replace --no-build with disk cleanup for nix-validate

### DIFF
--- a/.github/workflows/_nix-validate.yml
+++ b/.github/workflows/_nix-validate.yml
@@ -34,6 +34,24 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      # Free ~30GB on the ubuntu-latest runner so `nix flake check --all-systems`
+      # has space to substitute darwin source paths (rustc-src, cctools,
+      # apple-sdk, etc.) without hitting "No space left on device". The default
+      # runner image has ~14GB free; nix-darwin / nix-ai darwin closures need
+      # noticeably more than that. Keeps tool-cache (Node/Python/Go) intact for
+      # downstream steps. Replaces an earlier --no-build attempt that broke
+      # consumer checks referencing derivation outputs across platforms.
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          swap-storage: false
+          docker-images: true
+
       # determinate-nix-action@v3 is ONLY a Nix installer (replaced nix-installer-action@v21).
       # It does NOT include flake checking — that was a separate action (flake-checker-action).
       # Flake evaluation is handled by `nix flake check` below, not by the installer.
@@ -62,12 +80,13 @@ jobs:
             nix-linux-${{ runner.os }}-
 
       - name: Check flake
-        # --no-build: evaluate all systems' outputs without downloading/building
-        # derivations. Catches broken-package and evaluation errors cross-platform
-        # without exhausting disk on the linux runner (darwin packages like
-        # rustc-src, cctools, apple-sdk would otherwise be downloaded) or hitting
-        # "platform mismatch" build failures on aarch64-darwin-only derivations.
-        run: nix flake check --all-systems --no-build --print-build-logs --show-trace --keep-going
+        # --all-systems evaluates outputs for every declared system to catch
+        # darwin-only broken packages from the linux runner. Disk cleanup above
+        # ensures source-path substitution for darwin closures fits. --no-build
+        # is intentionally NOT used here: it disables substitution context for
+        # input flakes which breaks consumer checks that reference derivation
+        # outputs across platforms (e.g. nix-darwin/nix-ai module-eval).
+        run: nix flake check --all-systems --print-build-logs --show-trace --keep-going
 
       - name: Save Nix Store Cache
         if: github.event_name == 'push' && steps.nix-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/_nix-validate.yml
+++ b/.github/workflows/_nix-validate.yml
@@ -41,8 +41,13 @@ jobs:
       # noticeably more than that. Keeps tool-cache (Node/Python/Go) intact for
       # downstream steps. Replaces an earlier --no-build attempt that broke
       # consumer checks referencing derivation outputs across platforms.
+      #
+      # Gated to ubuntu-* runners only — never run on a self-hosted runner
+      # (RunsOn etc.), where removing preinstalled components would damage
+      # long-lived state.
       - name: Free disk space
-        uses: jlumbroso/free-disk-space@main
+        if: startsWith(inputs.runner_label, 'ubuntu-')
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:
           tool-cache: false
           android: true


### PR DESCRIPTION
## Summary
- Drop \`--no-build\` from \`_nix-validate.yml\` (added in #298)
- Add \`jlumbroso/free-disk-space@main\` before nix install to free ~30GB

## Why
#298 added \`--no-build\` to keep the ubuntu-latest runner from exhausting disk on darwin source substitution. That worked for nix-home (its module-eval was made lazy in JacobPEvans/nix-home#234), but broke nix-darwin and nix-ai checks that reference derivation outputs across platforms:

\`\`\`
error: path '<hash>-inputs' is not valid
error: path '<hash>-wrap-claude-command-…drv' is not valid
\`\`\`

\`--no-build\` disables substitution context realisation, which those checks legitimately need.

Switch strategy:
- Keep \`--all-systems\` (so darwin-only broken packages are still caught at eval, preserving #294's intent)
- Drop \`--no-build\`
- Free ~30GB via jlumbroso/free-disk-space (Android SDK, .NET, Haskell, Docker images)
- Tool-cache (Node/Python/Go) and large-packages stay intact for downstream steps

Universally compatible with existing consumer checks — no per-repo changes needed.

## Test plan
- [ ] After merge, re-trigger CI on nix-darwin #1091, nix-ai renovate PRs, nix-home renovate PR — Nix Validate should pass
- [ ] No new "No space left on device" failures

Assisted-by: Claude <noreply@anthropic.com>