### PR TITLE
fix(ci): make --all-systems opt-in via workflow input

### DIFF
--- a/.github/workflows/_nix-validate.yml
+++ b/.github/workflows/_nix-validate.yml
@@ -1,6 +1,6 @@
 # Reusable: Nix Validate
-# Runs nix flake check --all-systems to catch broken packages on all declared
-# systems (darwin included) from a linux runner before they merge.
+# Runs `nix flake check` for the current system, optionally with --all-systems
+# to catch packages broken on darwin from a linux runner before they merge.
 name: _nix-validate
 
 on:
@@ -14,6 +14,16 @@ on:
         type: string
         required: false
         default: ubuntu-latest
+      all_systems:
+        description: >-
+          Pass --all-systems to nix flake check to evaluate outputs for every
+          declared system from the runner. Defaults true. Set false for repos
+          whose check derivations are platform-specific (require darwin
+          binaries to build), since `nix flake check --all-systems` attempts
+          to build cross-platform checks and fails with "platform mismatch".
+        type: boolean
+        required: false
+        default: true
 
 concurrency:
   group: nix-validate-${{ github.workflow }}-${{ github.ref }}
@@ -36,17 +46,11 @@ jobs:
 
       # Free ~30GB on the ubuntu-latest runner so `nix flake check --all-systems`
       # has space to substitute darwin source paths (rustc-src, cctools,
-      # apple-sdk, etc.) without hitting "No space left on device". The default
-      # runner image has ~14GB free; nix-darwin / nix-ai darwin closures need
-      # noticeably more than that. Keeps tool-cache (Node/Python/Go) intact for
-      # downstream steps. Replaces an earlier --no-build attempt that broke
-      # consumer checks referencing derivation outputs across platforms.
-      #
-      # Gated to ubuntu-* runners only — never run on a self-hosted runner
-      # (RunsOn etc.), where removing preinstalled components would damage
-      # long-lived state.
+      # apple-sdk, etc.) without hitting "No space left on device". Only needed
+      # when all_systems is true; gated to ubuntu-* runners so self-hosted
+      # runner long-lived state is never modified.
       - name: Free disk space
-        if: startsWith(inputs.runner_label, 'ubuntu-')
+        if: inputs.all_systems && startsWith(inputs.runner_label, 'ubuntu-')
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:
           tool-cache: false
@@ -86,12 +90,12 @@ jobs:
 
       - name: Check flake
         # --all-systems evaluates outputs for every declared system to catch
-        # darwin-only broken packages from the linux runner. Disk cleanup above
-        # ensures source-path substitution for darwin closures fits. --no-build
-        # is intentionally NOT used here: it disables substitution context for
-        # input flakes which breaks consumer checks that reference derivation
-        # outputs across platforms (e.g. nix-darwin/nix-ai module-eval).
-        run: nix flake check --all-systems --print-build-logs --show-trace --keep-going
+        # darwin-only broken packages from the linux runner. Disabled by setting
+        # `all_systems: false` for repos whose checks build platform-specific
+        # derivations (require darwin binaries).
+        env:
+          ALL_SYSTEMS_FLAG: ${{ inputs.all_systems && '--all-systems' || '' }}
+        run: nix flake check $ALL_SYSTEMS_FLAG --print-build-logs --show-trace --keep-going
 
       - name: Save Nix Store Cache
         if: github.event_name == 'push' && steps.nix-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
## Summary
- Add \`all_systems: bool\` input to \`_nix-validate.yml\` (default \`true\`)
- Conditionally pass \`--all-systems\` to \`nix flake check\` based on the input
- Gate the disk-cleanup step on \`all_systems && ubuntu-*\` (only needed for cross-platform substitution)

## Why
\`nix flake check --all-systems\` attempts to BUILD outputs for every declared system, not just evaluate. Disk cleanup (#299) doesn't help — platform mismatch is a build-time issue. \`--no-build\` (#298) broke substitution context for input flakes.

Per-repo behavior under \`--all-systems\`:
- **nix-home** ✓ — module-eval was made platform-aware in JacobPEvans/nix-home#234 (lazy darwin skip). Works fine.
- **nix-darwin** ✗ — \`module-eval\` references darwin-only \`cfg.system.drvPath\`; platform-mismatch fails the build.
- **nix-ai** ✗ — \`wrap-claude-command-*\`, \`gemini-policy.toml\`, \`fabric-patterns-marketplace\`, etc. are runCommand derivations whose build requires darwin binaries.

Making the flag opt-in lets each consumer choose. nix-home keeps the default. nix-darwin and nix-ai pass \`all_systems: false\` in their ci-gate caller workflow until their checks are restructured (e.g. via \`unsafeDiscardStringContext\` or platform-conditional definitions).

## Follow-up
nix-darwin and nix-ai each need a small follow-up PR setting \`all_systems: false\` on the \`_nix-validate.yml\` caller in their respective \`.github/workflows/ci-gate.yml\`. I'll open those after this merges.

## Test plan
- [ ] CI Gate passes on this PR (.github itself doesn't have cross-platform checks)
- [ ] After merge + consumer caller updates, nix-darwin #1091/#1086 and nix-ai renovate PRs pass Nix Validate
- [ ] nix-home #231 stays green (uses default \`all_systems: true\`)

Assisted-by: Claude <noreply@anthropic.com>