### PR TITLE
feat(ci): fail PRs containing unsigned commits via shared CI gate

### DIFF
--- a/.github/scripts/signed-commits-check.js
+++ b/.github/scripts/signed-commits-check.js
@@ -1,9 +1,15 @@
 // Fails the calling workflow when any commit in the active pull request is not
 // verified by GitHub (GPG, S/MIME, or SSH signature). Designed to be invoked
-// from `_signed-commits-check.yml` via `actions/github-script`:
+// from `_signed-commits-check.yml` via `actions/github-script`. The reusable
+// workflow sparse-checks this file out of JacobPEvans/.github@main into
+// `./.gh-shared/.github/scripts/` on the consumer's runner, so the require()
+// path the workflow uses is:
 //
-//   const run = require('./.github/scripts/signed-commits-check.js');
+//   const run = require('./.gh-shared/.github/scripts/signed-commits-check.js');
 //   await run({ github, context, core });
+//
+// When running inside this repo's own CI (e.g. the dogfood gate), the script
+// is in-tree, so the path without the `.gh-shared/` prefix also works.
 //
 // Why this lives in a dedicated file: no off-the-shelf action exists for the
 // "fail-PR-on-any-unsigned-commit" check, and the pagination + filter + summary

--- a/.github/scripts/signed-commits-check.js
+++ b/.github/scripts/signed-commits-check.js
@@ -1,0 +1,65 @@
+// Fails the calling workflow when any commit in the active pull request is not
+// verified by GitHub (GPG, S/MIME, or SSH signature). Designed to be invoked
+// from `_signed-commits-check.yml` via `actions/github-script`:
+//
+//   const run = require('./.github/scripts/signed-commits-check.js');
+//   await run({ github, context, core });
+//
+// Why this lives in a dedicated file: no off-the-shelf action exists for the
+// "fail-PR-on-any-unsigned-commit" check, and the pagination + filter + summary
+// logic would balloon past the no-scripts inline limit if buried in YAML.
+
+module.exports = async ({ github, context, core }) => {
+  const pr = context.payload.pull_request;
+  if (!pr) {
+    core.info('No pull_request payload present; skipping signed-commits check.');
+    return;
+  }
+
+  const { owner, repo } = context.repo;
+  const commits = await github.paginate(github.rest.pulls.listCommits, {
+    owner,
+    repo,
+    pull_number: pr.number,
+    per_page: 100,
+  });
+
+  const unsigned = commits.filter((c) => c.commit.verification.verified === false);
+
+  if (unsigned.length === 0) {
+    core.info(`All ${commits.length} commit(s) in PR #${pr.number} are verified.`);
+    await core.summary
+      .addHeading('Signed commits check', 2)
+      .addRaw(`All ${commits.length} commit(s) verified.`)
+      .write();
+    return;
+  }
+
+  const rows = unsigned.map((c) => [
+    c.sha.slice(0, 8),
+    c.commit.author.name || '(unknown)',
+    c.commit.verification.reason || '(no reason reported)',
+  ]);
+
+  await core.summary
+    .addHeading('Unsigned commits detected', 2)
+    .addRaw(`PR #${pr.number} contains ${unsigned.length} unsigned commit(s) out of ${commits.length}.`)
+    .addTable([
+      [
+        { data: 'SHA', header: true },
+        { data: 'Author', header: true },
+        { data: 'Reason', header: true },
+      ],
+      ...rows,
+    ])
+    .write();
+
+  const lines = rows.map(([sha, author, reason]) => `  ${sha}  ${author}  (${reason})`);
+  core.setFailed(
+    [
+      `${unsigned.length} unsigned commit(s) detected in PR #${pr.number}:`,
+      ...lines,
+      'All commits must be GPG/SSH/S-MIME signed and verifiable by GitHub.',
+    ].join('\n'),
+  );
+};

--- a/.github/workflows/_ci-gate.yml
+++ b/.github/workflows/_ci-gate.yml
@@ -5,12 +5,13 @@
 #
 # What this workflow does:
 #
-#   changes  -> dorny/paths-filter on caller-supplied filters
-#   <check jobs> -> per-check reusable workflows, gated on (input toggle && filter)
-#   watchdog -> sleeps queue_timeout_minutes, cancels any sibling job still
-#               in `queued` state so the gate is never blocked indefinitely
-#   gate     -> name MUST stay "Merge Gate" (matches branch protection rulesets);
-#               aggregates results via re-actors/alls-green
+#   changes        -> dorny/paths-filter on caller-supplied filters
+#   <check jobs>   -> per-check reusable workflows, gated on (input toggle && filter)
+#   signed-commits -> always-on; fails the PR if any commit is verified:false
+#   watchdog       -> sleeps queue_timeout_minutes, cancels any sibling job still
+#                     in `queued` state so the gate is never blocked indefinitely
+#   gate           -> name MUST stay "Merge Gate" (matches branch protection rulesets);
+#                     aggregates results via re-actors/alls-green
 #
 # Why the watchdog exists:
 #
@@ -125,6 +126,14 @@ jobs:
       python-dirs: ${{ inputs.python_security_dirs }}
     secrets: inherit
 
+  # Always-on regression backstop for the org-wide "all automated commits must
+  # be verified" initiative. No filter gate, no input toggle: every PR runs it.
+  # Skipped on non-PR events so `re-actors/alls-green` accepts it as a skip.
+  signed-commits:
+    name: Signed Commits
+    if: ${{ github.event_name == 'pull_request' }}
+    uses: JacobPEvans/.github/.github/workflows/_signed-commits-check.yml@main
+
   # ============================================================================
   # WATCHDOG
   # Forces a terminal state for queued sibling jobs after queue_timeout_minutes.
@@ -164,7 +173,7 @@ jobs:
   # ============================================================================
   gate:
     name: Merge Gate
-    needs: [changes, watchdog, nix-validate, markdown-lint, file-size, python-security]
+    needs: [changes, watchdog, nix-validate, markdown-lint, file-size, python-security, signed-commits]
     if: ${{ always() && !cancelled() }}
     runs-on: ubuntu-latest
     steps:
@@ -173,5 +182,6 @@ jobs:
         with:
           # `watchdog` is always-success-on-completion; treating it as
           # allowed-skip lets `alls-green` ignore its result either way.
-          allowed-skips: nix-validate, markdown-lint, file-size, python-security, watchdog
+          # `signed-commits` is skipped on non-PR events (push) — also allowed.
+          allowed-skips: nix-validate, markdown-lint, file-size, python-security, watchdog, signed-commits
           jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/_signed-commits-check.yml
+++ b/.github/workflows/_signed-commits-check.yml
@@ -1,0 +1,43 @@
+# Reusable: Signed Commits Check
+#
+# Fails any pull request that contains a commit GitHub reports as
+# `verified:false`. This is the PR-level regression backstop behind the
+# `required_signatures` branch-protection rulesets — even if a ruleset is
+# bypassed (admin override, future ruleset edit) the PR can't get a green
+# check without signed commits.
+#
+# Safe to call from non-PR contexts: the script no-ops cleanly when
+# `context.payload.pull_request` is absent.
+name: _signed-commits-check
+
+on:
+  workflow_call:
+
+concurrency:
+  group: signed-commits-check-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  verify:
+    name: Verify signed commits
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout signed-commits-check script
+        uses: actions/checkout@v6
+        with:
+          repository: JacobPEvans/.github
+          ref: main
+          path: .gh-shared
+          sparse-checkout: .github/scripts/signed-commits-check.js
+          sparse-checkout-cone-mode: false
+
+      - name: Verify every commit in the PR is signed
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const run = require('./.gh-shared/.github/scripts/signed-commits-check.js');
+            await run({ github, context, core });


### PR DESCRIPTION
## Summary
- New reusable workflow `_signed-commits-check.yml` fails any PR where a commit is `verified:false`
- Wired into shared `_ci-gate.yml` so every downstream consumer gets it automatically
- This is the PR-level regression backstop — layered behind branch-protection rulesets (PR #4 of the initiative)

## Four-tier search log (no-scripts rule)

- **Tier 1 (Native CLIs)**: `gh api repos/.../pulls/<n>/commits` works, but pagination + JSON parsing + per-commit filter in bash exceeds the 10-line inline gate and is fragile.
- **Tier 2 (Ecosystem primitives)**: no off-the-shelf marketplace action exists for "fail PR on any unsigned commit". Closest match — `actions/github-script@v9` — IS first-party GitHub and is what this workflow uses.
- **Tier 3 (Third-party packaged tools)**: none found.
- **Tier 4 (Popular community solutions)**: none found.

Script extracted to `.github/scripts/signed-commits-check.js` per the no-scripts rule (logic exceeds the 10-line inline limit; allowed `.github/scripts/` directory).

## Implementation notes

- Failure path: `core.setFailed` with multi-line message listing each offending short-SHA, author, and `verification.reason`. `core.summary` also writes a markdown table to the job summary so failures are browsable in the GitHub UI.
- Success path: `core.info` confirms N commits verified, summary writes a one-line confirmation.
- Safe in non-PR contexts: script no-ops cleanly when `context.payload.pull_request` is absent.
- The `signed-commits` job in `_ci-gate.yml` is gated on `github.event_name == 'pull_request'` and listed as an allowed-skip in `re-actors/alls-green`.

## Verification (after merge)
- Open a sacrificial PR with an intentionally unsigned commit (e.g. `git commit --no-gpg-sign -m test`) on a consumer repo
- Confirm `_ci-gate.yml` fails with a clear message listing the offending SHA
- Sign and force-push; confirm CI passes

Part of the 8-PR "eliminate unsigned automated commits" initiative.
Plan: `~/.claude/plans/you-are-opus-on-breezy-valiant.md`

Assisted-by: Claude <noreply@anthropic.com>