### PR TITLE
feat(ci): integrate no-runner-git-commit hook into shared CI gate

### DIFF
--- a/.github/workflows/_ci-gate.yml
+++ b/.github/workflows/_ci-gate.yml
@@ -22,9 +22,10 @@
 #
 # Filter name convention (caller defines these in `filters:` input):
 #
-#   nix            -> gates `nix_validate`
-#   markdown       -> gates `markdown_lint` and `file_size`
-#   python         -> gates `python_security`
+#   nix             -> gates `nix_validate`
+#   markdown        -> gates `markdown_lint` and `file_size`
+#   python          -> gates `python_security`
+#   github_actions  -> gates `no_runner_git_commit`
 #
 # Callers may include additional filters; this workflow ignores them. To add
 # a new conditional check, add: input toggle, conditional job, and entry in
@@ -62,6 +63,13 @@ on:
         description: Space-separated dirs passed to _python-security.yml
         type: string
         default: ''
+      no_runner_git_commit:
+        description: >-
+          Enable `No Runner Git Commit` (Layer 5 of the signed-commits
+          initiative — blocks raw `git commit` / `git push` in workflow
+          YAML). Gated on `github_actions` filter.
+        type: boolean
+        default: false
 
       queue_timeout_minutes:
         description: >-
@@ -86,6 +94,7 @@ jobs:
       nix: ${{ steps.filter.outputs.nix }}
       markdown: ${{ steps.filter.outputs.markdown }}
       python: ${{ steps.filter.outputs.python }}
+      github_actions: ${{ steps.filter.outputs.github_actions }}
     steps:
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v4
@@ -124,6 +133,12 @@ jobs:
     with:
       python-dirs: ${{ inputs.python_security_dirs }}
     secrets: inherit
+
+  no-runner-git-commit:
+    name: No Runner Git Commit
+    needs: changes
+    if: ${{ inputs.no_runner_git_commit && needs.changes.outputs.github_actions == 'true' }}
+    uses: JacobPEvans/.github/.github/workflows/_no-runner-git-commit.yml@main
 
   # ============================================================================
   # WATCHDOG
@@ -164,7 +179,7 @@ jobs:
   # ============================================================================
   gate:
     name: Merge Gate
-    needs: [changes, watchdog, nix-validate, markdown-lint, file-size, python-security]
+    needs: [changes, watchdog, nix-validate, markdown-lint, file-size, python-security, no-runner-git-commit]
     if: ${{ always() && !cancelled() }}
     runs-on: ubuntu-latest
     steps:
@@ -173,5 +188,5 @@ jobs:
         with:
           # `watchdog` is always-success-on-completion; treating it as
           # allowed-skip lets `alls-green` ignore its result either way.
-          allowed-skips: nix-validate, markdown-lint, file-size, python-security, watchdog
+          allowed-skips: nix-validate, markdown-lint, file-size, python-security, no-runner-git-commit, watchdog
           jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/_no-runner-git-commit.yml
+++ b/.github/workflows/_no-runner-git-commit.yml
@@ -1,0 +1,46 @@
+# Reusable: No Runner Git Commit
+#
+# Layer 5 of the signed-commits initiative. Scans `.github/workflows/*.yml`
+# and `.github/actions/**/action.yml` in the calling repo, failing the job
+# if any `run:` step contains raw `git commit` or `git push` outside the
+# documented allowlist (Contents API, peter-evans/create-pull-request,
+# the `_ai-action-with-signing.yml` wrapper).
+#
+# Authoring source: ai-assistant-instructions/scripts/check-no-runner-git-commit.sh
+# Source rule: agentsmd/rules/git-signing.md
+name: _no-runner-git-commit
+
+on:
+  workflow_call:
+
+concurrency:
+  group: no-runner-git-commit-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: No Runner Git Commit
+    runs-on: ubuntu-latest
+    # Hard cap so a wedged scan can't block `Merge Gate` indefinitely.
+    timeout-minutes: 5
+    steps:
+      - name: Checkout caller repo
+        uses: actions/checkout@v6
+
+      - name: Sparse-checkout hook script from ai-assistant-instructions
+        uses: actions/checkout@v6
+        with:
+          repository: JacobPEvans/ai-assistant-instructions
+          ref: main
+          path: .aai
+          sparse-checkout: scripts/check-no-runner-git-commit.sh
+          sparse-checkout-cone-mode: false
+
+      - name: Install yq (Python wrapper around jq used by the hook)
+        run: pipx install yq
+
+      - name: Run hook
+        run: bash .aai/scripts/check-no-runner-git-commit.sh


### PR DESCRIPTION
## Summary

Layer 5 (CI half) of the 8-PR signed-commits initiative. Wires the
`check-no-runner-git-commit.sh` hook (added in the companion PR over in
`JacobPEvans/ai-assistant-instructions`) into the shared CI gate so
every consumer repo catches the violation during PR validation, not
just locally via pre-commit.

## Changes

- **New**: `.github/workflows/_no-runner-git-commit.yml` — a reusable
  workflow that sparse-checks out the hook script from
  `JacobPEvans/ai-assistant-instructions@main` and runs it against the
  caller repo. Single source of truth: the script lives there; this
  workflow just transports it.
- **Modified**: `.github/workflows/_ci-gate.yml`
  - new input toggle `no_runner_git_commit` (bool, default `false` — opt-in per consumer)
  - new filter convention `github_actions` documented in the file header
  - new job `no-runner-git-commit`, gated on `(toggle && filter)`
  - added to `gate.needs` and `allowed-skips`

## What the hook catches

See the companion PR for the full allowlist. TL;DR: any raw
`git commit` / `git push` in `.github/workflows/*.yml` or
`.github/actions/**/action.yml` outside of:

- Contents API calls (`gh api repos/.../contents/...`)
- `peter-evans/create-pull-request`
- The canonical SSH-signing wrapper (`_ai-action-with-signing.yml`)
- Markdown bodies passed to `gh pr/issue create` / `actions/github-script`

## Why a reusable workflow (not an inline job)

Consistent with the existing pattern in this repo — every conditional
check (`_nix-validate.yml`, `_markdown-lint.yml`, `_file-size.yml`,
`_python-security.yml`) is its own reusable workflow that `_ci-gate.yml`
calls. Keeps `_ci-gate.yml` declarative, isolates concurrency groups,
and lets repos that don't use `_ci-gate.yml` call the check directly.

## Test plan

- [x] `actionlint` clean on both modified files
- [x] `check-yaml` pre-commit hook passes on both
- [x] Default `false` — no consumer gets the check until they opt in (no surprise CI breakage)
- [x] Git commit signature verified (`git log -1 --format='%G?'` → `G`)

## Companion PR

`JacobPEvans/ai-assistant-instructions#632`: `feat(hooks): block raw git commit/push in workflow YAML`

Assisted-by: Claude <noreply@anthropic.com>