### PR TITLE
feat(renovate): lift grouping rules and add stability features to preset

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,12 +10,12 @@ that don't define their own versions.
 ## Key Files
 
 - `renovate.json` — Renovate config extending `config:recommended` and local presets
+- `renovate-presets.json` — Org-wide Renovate preset. Inline `description` fields are canonical docs. Extend from other repos via `local>JacobPEvans/.github:renovate-presets`.
 - `.github/labels.yml` — Canonical label definitions deployed to all repos via `label-sync.yml`
 - `.github/workflows/label-sync.yml` — Syncs `labels.yml` to all repos on push to main
 - `.github/ISSUE_TEMPLATE/` — Issue forms (bug, feature, docs, chore); all require `priority` + `size` labels
 - `.github/PULL_REQUEST_TEMPLATE/` — PR templates per change type; all require Conventional Commits format
 - `docs/CONTRIBUTING.md` — Inherited contributing guidelines
-- `docs/RENOVATE.md` — Renovate onboarding guide (always extend the org preset)
 
 ## Common Tasks
 

--- a/renovate-grouping.json
+++ b/renovate-grouping.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": [
+    "JacobPEvans org-wide Renovate grouping preset.",
+    "Batches related dependency updates into single PRs to reduce review burden and prevent deploy-queue saturation. Extended by renovate-presets.json — do not extend this directly from consumers, extend renovate-presets instead. Adding a new ecosystem grouping? Add a packageRule here with a clear description explaining why the packages must move together."
+  ],
+  "packageRules": [
+    {
+      "description": "Group Terraform providers, modules, and Terragrunt updates into a single PR. Prevents deploy-queue saturation when a provider bump arrives alongside a terragrunt dependency. Applies to every repo using either manager.",
+      "matchManagers": ["terraform", "terragrunt"],
+      "groupName": "Terraform & Terragrunt"
+    },
+    {
+      "description": "Group Ansible Galaxy collection updates. Collections almost always release together (e.g., community.general + ansible.posix) and breakage manifests at the playbook level, so reviewing them as a unit is correct.",
+      "matchManagers": ["ansible-galaxy"],
+      "groupName": "Ansible collections"
+    },
+    {
+      "description": "Group OpenTelemetry packages across npm and Python. OTel releases SDKs in lockstep — mixing versions across instrumentation packages causes silent dropped spans.",
+      "matchPackageNames": ["@opentelemetry/**", "opentelemetry-**"],
+      "groupName": "OpenTelemetry"
+    },
+    {
+      "description": "Group TypeScript type definitions (@types/*). Type-only updates are mechanical and almost never break runtime behavior. Auto-merged minor/patch.",
+      "matchPackageNames": ["@types/**"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "TypeScript types",
+      "automerge": true
+    },
+    {
+      "description": "Group ESLint core and TypeScript-aware ESLint plugins. typescript-eslint releases as a monorepo with matched versions across @typescript-eslint/parser, @typescript-eslint/eslint-plugin, etc. — they must move together.",
+      "matchPackageNames": [
+        "eslint",
+        "eslint-**",
+        "@eslint/**",
+        "@typescript-eslint/**",
+        "typescript-eslint",
+        "typescript"
+      ],
+      "groupName": "ESLint & TypeScript"
+    },
+    {
+      "description": "Group pytest core and pytest-* plugins. Plugin compatibility is tied to pytest minor versions; batching prevents version-skew breakages in CI.",
+      "matchDatasources": ["pypi"],
+      "matchPackageNames": ["pytest", "pytest-**"],
+      "groupName": "pytest"
+    },
+    {
+      "description": "Group AWS SDK packages across npm (@aws-sdk/*, aws-sdk) and Python (boto3, botocore). AWS releases these as a coordinated set — botocore feeds boto3, @aws-sdk submodules share a version.",
+      "matchPackageNames": [
+        "aws-sdk",
+        "@aws-sdk/**",
+        "boto3",
+        "botocore",
+        "s3transfer"
+      ],
+      "groupName": "AWS SDK"
+    },
+    {
+      "description": "Group HuggingFace ecosystem packages. transformers + tokenizers + datasets + accelerate + huggingface-hub have tightly-coupled version requirements; partial updates routinely break imports.",
+      "matchPackageNames": [
+        "transformers",
+        "tokenizers",
+        "datasets",
+        "accelerate",
+        "huggingface-hub",
+        "safetensors",
+        "evaluate"
+      ],
+      "groupName": "HuggingFace"
+    }
+  ]
+}

--- a/renovate-presets.json
+++ b/renovate-presets.json
@@ -1,14 +1,26 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "description": [
-    "JacobPEvans org-wide Renovate preset",
+    "JacobPEvans org-wide Renovate preset — entry point. Consumers extend this via local>JacobPEvans/.github:renovate-presets.",
+    "Architecture: this file holds global policy (auto-merge, trusted orgs, stability features, custom managers). Ecosystem grouping rules live in renovate-grouping.json and are pulled in via extends below. Inline description fields on each rule are the canonical documentation — keep them current.",
     "WARNING: platformAutomerge MUST stay false. GitHub's auto-merge queue has a known bug (RC3) where PRs pass all checks but GitHub never executes the merge — PRs stall for days with no error. With false, Renovate merges directly via API with built-in retry logic. See PR #196 for full history. Do NOT set this to true."
+  ],
+  "extends": [
+    "local>JacobPEvans/.github:renovate-grouping"
   ],
   "platformAutomerge": false,
   "baseBranchPatterns": ["$default"],
   "automergeType": "pr",
   "automergeStrategy": "squash",
   "pinGitHubActionDigests": true,
+  "dependencyDashboard": true,
+  "dependencyDashboardLabels": ["dependencies"],
+  "dependencyDashboardOSVVulnerabilitySummary": "unresolved",
+  "prConcurrentLimit": 5,
+  "branchConcurrentLimit": 3,
+  "rebaseWhen": "conflicted",
+  "ignoreDeprecated": true,
+  "osvVulnerabilityAlerts": true,
   "ignorePaths": [
     ".github/workflows/*.lock.yml",
     ".github/workflows/agentics-maintenance.yml",


### PR DESCRIPTION
## Feature Description

Lifts dependency grouping rules and modern Renovate stability features into the org-wide preset (`renovate-presets.json`), so every consuming repo inherits them automatically.

Splits the new grouping rules into a sibling preset (`renovate-grouping.json`) referenced via `extends` — keeps each file under the 10 KB pre-commit guardrail and gives each preset a single responsibility.

## Problem Statement

`JacobPEvans/terraform-runs-on` PR #46 grouped Terraform + Terragrunt updates locally to stop deploy-queue saturation. The fix was correct but applied at the wrong level — the same rule would need to be duplicated across every repo using both managers.

Survey of JacobPEvans + dryvist repos found:

- 4 repos use Terraform + Terragrunt with no grouping today
- 3 Ansible repos duplicate identical `ansible-galaxy` grouping rules
- 9 npm-based Cribl Edge packs share `@opentelemetry/*` / `@types/*` ecosystems with no grouping
- No repo uses dependency dashboards, PR concurrency caps, or conflict-only rebases

All of this belongs at the preset level. Renovate concatenates `packageRules` from extended presets, so one definition propagates to every consumer.

## Solution Design

### New grouping rules (in `renovate-grouping.json`)

Eight conservative, well-known ecosystem groups:

| Group | Match |
|---|---|
| Terraform & Terragrunt | `matchManagers: [terraform, terragrunt]` |
| Ansible collections | `matchManagers: [ansible-galaxy]` |
| OpenTelemetry | `@opentelemetry/**`, `opentelemetry-**` |
| TypeScript types | `@types/**` (auto-merged minor/patch) |
| ESLint & TypeScript | `eslint`, `eslint-**`, `@typescript-eslint/**`, etc. |
| pytest | `pytest`, `pytest-**` on PyPI |
| AWS SDK | `aws-sdk`, `@aws-sdk/**`, `boto3`, `botocore`, `s3transfer` |
| HuggingFace | `transformers`, `tokenizers`, `datasets`, `accelerate`, etc. |

No blanket "all minor weekly" buckets — those mask individual changes (rejected during scoping).

### New stability features (in `renovate-presets.json`)

- `dependencyDashboard: true` + `dependencyDashboardLabels: ["dependencies"]` — one issue per repo summarizing all pending updates
- `dependencyDashboardOSVVulnerabilitySummary: "unresolved"` — surface OSV vulns on the dashboard
- `prConcurrentLimit: 5` / `branchConcurrentLimit: 3` — prevents the deploy-queue saturation that motivated terraform-runs-on #46
- `rebaseWhen: "conflicted"` — only rebase when actually conflicted (massive CI-minute reduction vs. default `"auto"`)
- `ignoreDeprecated: true` — skip PRs for registry-deprecated packages
- `osvVulnerabilityAlerts: true` — supplement GitHub vuln alerts with OSV's broader DB

### Architecture: split into two presets

`renovate-presets.json` (entry point) now extends `local>JacobPEvans/.github:renovate-grouping`. Consumers continue to extend `local>JacobPEvans/.github:renovate-presets` — no consumer changes needed.

### Documentation

Per scoping decision: inline `description` fields on every rule and at the file level are the canonical documentation. No separate `docs/RENOVATE.md` — and the stale reference to that non-existent file has been removed from `CLAUDE.md`.

## Related Issues

- Supersedes JacobPEvans/terraform-runs-on#46 (close after this merges and the next Renovate cycle batches Terraform+Terragrunt via the preset)

## Changes Made

### New Files

- `renovate-grouping.json` — new sibling preset containing the eight grouping rules

### Modified Files

- `renovate-presets.json` — added `extends` chain to grouping preset, plus seven stability top-level keys; fixed `dependencyDashboardOSVVulnerabilitySummary` to its string-valued form
- `CLAUDE.md` — added pointer to `renovate-presets.json` as canonical docs, removed stale `docs/RENOVATE.md` reference

## Testing

- [x] `python3 -m json.tool` on both preset files — valid JSON
- [x] `npx renovate@latest renovate-config-validator` — `renovate-grouping.json` and `renovate.json` validate cleanly; one pre-existing false positive on `renovate-presets.json` (`pinGitHubActionDigests` flagged because the validator treats preset files as global config, but the option is valid in actual preset use — has been in the file and working in production)
- [x] Pre-commit hooks all pass (markdownlint, file size, link check, etc.)
- [ ] Post-merge: verify dependency dashboard issue appears in a canary repo within one Renovate cycle
- [ ] Post-merge: verify `terraform-proxmox` next Renovate run produces a single "Terraform & Terragrunt" PR rather than separate provider PRs

## Performance Impact

Net positive — `rebaseWhen: "conflicted"` alone should significantly reduce CI minutes across consuming repos (default rebases on every `main` push). `prConcurrentLimit` and `branchConcurrentLimit` further cap background CI churn.

## Labels

- [x] **Type**: `type:feature`
- [x] **Priority**: `priority:medium`
- [x] **Size**: `size:m`

## Checklist

- [x] PR title follows conventional commits format
- [x] All commits are signed
- [x] Self-review completed

## Additional Context

Follow-up cleanup (separate PRs, will queue once this merges):

1. Close `terraform-runs-on` PR #46 with superseded-by comment
2. Remove duplicate `ansible-galaxy` `packageRules` from `ansible-proxmox`, `ansible-splunk`, `ansible-proxmox-apps`
3. Add this preset to `claude-code-routines/renovate.json` (currently only extends `config:recommended`)
4. Bootstrap `dryvist/.github/renovate-presets.json` extending this preset, then migrate dryvist consumer repos