### PR TITLE
feat(ci): pass all_systems through _ci-gate.yml to _nix-validate.yml

### DIFF
--- a/.github/workflows/_ci-gate.yml
+++ b/.github/workflows/_ci-gate.yml
@@ -46,6 +46,16 @@ on:
         description: Enable `Nix Validate` (gated on `nix` filter)
         type: boolean
         default: false
+      all_systems:
+        description: >-
+          Pass --all-systems to `nix flake check`. Default true catches
+          darwin-only `meta.broken` packages from a linux runner. Set false
+          only when consumer flakes declare platform-specific check
+          derivations that cannot be made platform-aware (rare — prefer
+          fixing the flake to use `runCommandLocal` or to scope source-only
+          checks to the CI system).
+        type: boolean
+        default: true
       markdown_lint:
         description: Enable `Markdown Lint` (gated on `markdown` filter)
         type: boolean
@@ -103,6 +113,8 @@ jobs:
     needs: changes
     if: ${{ inputs.nix_validate && needs.changes.outputs.nix == 'true' }}
     uses: JacobPEvans/.github/.github/workflows/_nix-validate.yml@main
+    with:
+      all_systems: ${{ inputs.all_systems }}
 
   markdown-lint:
     name: Markdown Lint


### PR DESCRIPTION
## Summary

- PR #300 added an `all_systems` input to `_nix-validate.yml` (default `true`) so platform-specific consumer flakes could opt out of `--all-systems`. But `_ci-gate.yml` — which most consumer repos actually call — does not pass that input through, leaving consumers no clean opt-out lever.
- This PR closes that hole: add `all_systems` input to `_ci-gate.yml` and forward it to the `nix-validate` reusable job. Default remains `true` so we keep catching darwin-only `meta.broken` packages from the linux runner.

## Why this matters

Real evidence of the missing lever: nix-home [PR #240](https://github.com/JacobPEvans/nix-home/pull/240) [run 25863775332](https://github.com/JacobPEvans/nix-home/actions/runs/25863775332/job/76007042675) fails with 12 platform-mismatch errors on `checks.aarch64-linux.*`, `checks.x86_64-darwin.*`, `checks.aarch64-darwin.*`. Without this passthrough, nix-home cannot opt out from its `_ci-gate.yml` caller without forking the workflow.

## Important: this is a defensive safety valve, not the root-cause fix

The actual root cause is consumer flakes declaring `checks.<system>.foo = pkgs.<system>.runCommand ...` for every declared system. `runCommand` requires the platform's hardware to execute, so cross-platform check derivations fail with "platform mismatch" from the linux runner.

The root-cause fix lives in each consumer flake:
- **Source-only checks** (`formatting`, `shellcheck`, `deadnix`, `statix`) — declare only on `x86_64-linux` (the CI system). Source files are identical across systems.
- **Per-system eval checks** (`module-eval`) — use `runCommandLocal` instead of `runCommand` so they don't require platform-specific builders.

Follow-up PRs to nix-home, nix-darwin, nix-ai (and any other affected consumers) will apply the flake-level fix so `--all-systems` succeeds with no opt-out needed.

## Test plan

- [ ] CI on this PR passes (Markdown Lint, File Size, Merge Gate)
- [ ] After merge, a consumer can set `all_systems: false` in their `_ci-gate.yml` caller and observe `--all-systems` is dropped from the `nix flake check` invocation
- [ ] Default behavior unchanged for callers that do not pass `all_systems`