### PR TITLE
docs(renovate): document hash fields not updated by custom manager

### DIFF
--- a/renovate-presets.json
+++ b/renovate-presets.json
@@ -44,7 +44,7 @@
   },
   "customManagers": [
     {
-      "description": "Renovate-annotated version pins in Nix files",
+      "description": "Renovate-annotated version pins in Nix files. HASH FIELDS ARE NOT UPDATED — only version strings. Each repo's fix-renovate-hashes.yml runs nix-update to fix adjacent hash = \"sha256-...\" fields after Renovate bumps a version. When adding a new fetchPypi/fetchurl package with a Renovate annotation, also add it to that repo's nix-update workflow and flake packages output.",
       "customType": "regex",
       "managerFilePatterns": ["/\\.nix$/"],
       "matchStrings": [


### PR DESCRIPTION
## Summary

- Documents in the custom Nix regex manager description that hash fields (`hash = "sha256-..."`) are NOT updated by Renovate
- Directs maintainers to `fix-renovate-hashes.yml` in each repo for automated hash correction
- Explains that new `fetchPypi`/`fetchurl` packages need to be added to both the nix-update workflow and flake packages output

## Why

Renovate's custom regex manager silently leaves hash fields stale after version bumps. Without this documentation, the gap is invisible — maintainers don't know to wire up hash automation when adding new Nix-packaged dependencies.

## Test plan

- [ ] Verify renovate-presets.json is valid JSON
- [ ] Confirm Renovate can parse the preset (no schema errors in next Renovate run)

Assisted-by: Claude <noreply@anthropic.com>