### PR TITLE
fix(gh-aw): prune stale imports cache before compile

### DIFF
--- a/.github/actions/gh-aw-soak-refresh/refresh.sh
+++ b/.github/actions/gh-aw-soak-refresh/refresh.sh
@@ -20,6 +20,13 @@ trap 'rm -f "$BEFORE"' EXIT
 
 git show "HEAD:$LOCK" >"$BEFORE" 2>/dev/null || echo '{"entries":{}}' >"$BEFORE"
 
+# Wipe the SHA-keyed import cache so old folders don't accumulate alongside
+# new ones on every refresh. `gh aw compile` regenerates the cache (including
+# .gitattributes) from current import refs in the workflow .md files; the
+# resulting create-pull-request commit then contains the deletes and the
+# adds in one atomic diff.
+rm -rf .github/aw/imports
+
 gh aw compile --force-refresh-action-pins
 
 NOW=$(date -u +%s)


### PR DESCRIPTION
## Summary

- The weekly `gh-aw-pin-refresh` automation creates PRs (e.g. [JacobPEvans/ansible-proxmox-apps#251](https://github.com/JacobPEvans/ansible-proxmox-apps/pull/251)) that **add** new `.github/aw/imports/<owner>/<repo>/<sha>/` cache folders but **never remove the old ones**. Each refresh leaves more cruft behind; ansible-proxmox-apps had 17 stale folders, nix-ai 17, ansible-splunk 15.
- Adds a single `rm -rf .github/aw/imports` to `refresh.sh` before the first `gh aw compile`. The cache regenerates from current import refs in the workflow .md files, so the PR opened by `peter-evans/create-pull-request` contains the deletes and the adds in one atomic diff — exactly the requested behavior.
- Fan-out: 14 caller repos consume `_gh-aw-pin-refresh.yml@main` and pick up the fix automatically with zero per-repo changes.

## Why this approach

`gh aw` has no native prune flag for the imports cache (verified against `pkg/parser/import_cache.go` and `pkg/cli/compile_pipeline.go` in upstream `github/gh-aw`). The only built-in "purge" is for stale `.lock.yml` files.

The same wipe-before-compile pattern is already proven in `ai-workflows/.github/workflows/gh-aw-sync-upstream.yml:50`, running weekly since 2026-04-11 with no regressions. `.gitattributes` is recreated by `gh aw compile` automatically.

The 24h soak logic (rewinding action SHAs in `actions-lock.json`) is independent of the workflow imports cache, so wiping imports does not affect the soak.

## Test plan

- [x] Local sanity check on `ansible-proxmox-apps/main`: wipe + recompile reduced 17 SHA folders to 2 (one current SHA per upstream); `.gitattributes` preserved; diff showed -6972 lines (deletions of stale imports).
- [x] `bash -n refresh.sh` syntax-clean.
- [x] Pre-commit hooks pass.
- [ ] After merge: trigger `gh-aw-pin-refresh` workflow_dispatch on `ansible-proxmox-apps` (worst offender) and `nix-ai`. The first PR per repo will be larger than usual (one-time normalization deleting accumulated cruft); subsequent weekly PRs return to a small one-folder-out, one-folder-in pattern.

## Out of scope

- Backfill of existing PR branches' stale folders — they get cleaned by the next refresh cycle automatically.
- Same wipe in `agentics-maintenance.yml` — auto-generated by `gh aw compile`, not safe to hand-edit; only touches imports on manual `workflow_dispatch` of `update`/`upgrade`.
- Filing an upstream issue with `github/gh-aw` for a native `--prune-imports` flag — wrapper fix is sufficient and ships immediately.