### PR TITLE
feat(reusable-workflows): add runner_label input for RunsOn opt-in

### DIFF
--- a/.github/workflows/_ci-gate.yml
+++ b/.github/workflows/_ci-gate.yml
@@ -73,6 +73,19 @@ on:
         type: string
         default: ''
 
+      runner_label:
+        description: >-
+          GitHub Actions runner label for the orchestration jobs in this
+          workflow (`Detect Changes`, `Queue Watchdog`, `Merge Gate`). Also
+          passed through to every child reusable workflow this gate calls
+          (`Nix Validate`, `Markdown Lint`, `File Size`, `Python Security`),
+          so a single input migrates the whole gate.
+          Defaults to ubuntu-latest. Pass a RunsOn label
+          (see runs-on.com/configuration/job-labels) to opt in.
+        type: string
+        required: false
+        default: ubuntu-latest
+
       queue_timeout_minutes:
         description: >-
           Minutes the watchdog waits before cancelling sibling jobs still in

--- a/.github/workflows/_ci-gate.yml
+++ b/.github/workflows/_ci-gate.yml
@@ -91,7 +91,7 @@ jobs:
   # ============================================================================
   changes:
     name: Detect Changes
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner_label }}
     outputs:
       nix: ${{ steps.filter.outputs.nix }}
       markdown: ${{ steps.filter.outputs.markdown }}
@@ -115,18 +115,23 @@ jobs:
     uses: JacobPEvans/.github/.github/workflows/_nix-validate.yml@main
     with:
       all_systems: ${{ inputs.all_systems }}
+      runner_label: ${{ inputs.runner_label }}
 
   markdown-lint:
     name: Markdown Lint
     needs: changes
     if: ${{ inputs.markdown_lint && needs.changes.outputs.markdown == 'true' }}
     uses: JacobPEvans/.github/.github/workflows/_markdown-lint.yml@main
+    with:
+      runner_label: ${{ inputs.runner_label }}
 
   file-size:
     name: File Size
     needs: changes
     if: ${{ inputs.file_size && (needs.changes.outputs.nix == 'true' || needs.changes.outputs.markdown == 'true') }}
     uses: JacobPEvans/.github/.github/workflows/_file-size.yml@main
+    with:
+      runner_label: ${{ inputs.runner_label }}
 
   python-security:
     name: Python Security
@@ -135,6 +140,7 @@ jobs:
     uses: JacobPEvans/.github/.github/workflows/_python-security.yml@main
     with:
       python-dirs: ${{ inputs.python_security_dirs }}
+      runner_label: ${{ inputs.runner_label }}
     secrets: inherit
 
   # ============================================================================
@@ -145,7 +151,7 @@ jobs:
   watchdog:
     name: Queue Watchdog
     needs: changes
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner_label }}
     permissions:
       actions: write   # required to cancel sibling jobs
       contents: read   # required for actions/checkout sparse-checkout
@@ -178,7 +184,7 @@ jobs:
     name: Merge Gate
     needs: [changes, watchdog, nix-validate, markdown-lint, file-size, python-security]
     if: ${{ always() && !cancelled() }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner_label }}
     steps:
       - name: Aggregate results
         uses: re-actors/alls-green@release/v1

--- a/.github/workflows/_cribl-pack-validate.yml
+++ b/.github/workflows/_cribl-pack-validate.yml
@@ -9,6 +9,14 @@ on:
         description: "Pack type: edge or stream"
         required: true
         type: string
+      runner_label:
+        description: >-
+          GitHub Actions runner label. Defaults to ubuntu-latest. Pass a
+          RunsOn label (see runs-on.com/configuration/job-labels) to opt
+          the calling repo into self-hosted runners.
+        type: string
+        required: false
+        default: ubuntu-latest
 
 concurrency:
   group: cribl-pack-validate-${{ github.workflow }}-${{ github.ref }}
@@ -20,7 +28,7 @@ permissions:
 jobs:
   validate:
     name: Validate
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner_label }}
     steps:
       - name: Checkout pack repo
         uses: actions/checkout@v6

--- a/.github/workflows/_file-size.yml
+++ b/.github/workflows/_file-size.yml
@@ -16,6 +16,15 @@ name: _file-size
 
 on:
   workflow_call:
+    inputs:
+      runner_label:
+        description: >-
+          GitHub Actions runner label. Defaults to ubuntu-latest. Pass a
+          RunsOn label (see runs-on.com/configuration/job-labels) to opt
+          the calling repo into self-hosted runners.
+        type: string
+        required: false
+        default: ubuntu-latest
 
 permissions: {}
 
@@ -26,7 +35,7 @@ concurrency:
 jobs:
   check:
     name: Check
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner_label }}
     permissions:
       contents: read
     steps:

--- a/.github/workflows/_gh-aw-pin-refresh.yml
+++ b/.github/workflows/_gh-aw-pin-refresh.yml
@@ -37,6 +37,14 @@ on:
         description: 'compile = refresh SHA pins only; upgrade = full gh-aw infrastructure update'
         type: string
         default: 'compile'
+      runner_label:
+        description: >-
+          GitHub Actions runner label. Defaults to ubuntu-latest. Pass a
+          RunsOn label (see runs-on.com/configuration/job-labels) to opt
+          the calling repo into self-hosted runners.
+        type: string
+        required: false
+        default: ubuntu-latest
     secrets:
       GH_APP_PRIVATE_KEY:
         required: true
@@ -47,7 +55,7 @@ permissions: {}
 
 jobs:
   refresh-pins:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner_label }}
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/_markdown-lint.yml
+++ b/.github/workflows/_markdown-lint.yml
@@ -4,6 +4,15 @@ name: _markdown-lint
 
 on:
   workflow_call:
+    inputs:
+      runner_label:
+        description: >-
+          GitHub Actions runner label. Defaults to ubuntu-latest. Pass a
+          RunsOn label (see runs-on.com/configuration/job-labels) to opt
+          the calling repo into self-hosted runners.
+        type: string
+        required: false
+        default: ubuntu-latest
 
 concurrency:
   group: markdown-lint-${{ github.workflow }}-${{ github.ref }}
@@ -15,7 +24,7 @@ permissions:
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner_label }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/_osv-scan.yml
+++ b/.github/workflows/_osv-scan.yml
@@ -6,7 +6,16 @@
 name: _osv-scan
 
 on:
-  workflow_call: {}
+  workflow_call:
+    inputs:
+      runner_label:
+        description: >-
+          GitHub Actions runner label. Defaults to ubuntu-latest. Pass a
+          RunsOn label (see runs-on.com/configuration/job-labels) to opt
+          the calling repo into self-hosted runners.
+        type: string
+        required: false
+        default: ubuntu-latest
 
 concurrency:
   group: osv-scan-${{ github.workflow }}-${{ github.ref }}
@@ -18,7 +27,7 @@ permissions:
 jobs:
   osv-scan:
     name: OSV Scanner
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner_label }}
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/_python-security.yml
+++ b/.github/workflows/_python-security.yml
@@ -20,6 +20,14 @@ on:
         required: false
         type: string
         default: ''
+      runner_label:
+        description: >-
+          GitHub Actions runner label. Defaults to ubuntu-latest. Pass a
+          RunsOn label (see runs-on.com/configuration/job-labels) to opt
+          the calling repo into self-hosted runners.
+        type: string
+        required: false
+        default: ubuntu-latest
 
 concurrency:
   group: python-security-${{ github.workflow }}-${{ github.ref }}
@@ -31,7 +39,7 @@ permissions:
 jobs:
   pip-audit:
     name: pip-audit
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner_label }}
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/_release-please-auto-merge.yml
+++ b/.github/workflows/_release-please-auto-merge.yml
@@ -54,6 +54,14 @@ on:
           to use the repository's default branch.
         type: string
         default: ''
+      runner_label:
+        description: >-
+          GitHub Actions runner label. Defaults to ubuntu-latest. Pass a
+          RunsOn label (see runs-on.com/configuration/job-labels) to opt
+          the calling repo into self-hosted runners.
+        type: string
+        required: false
+        default: ubuntu-latest
     secrets:
       GH_APP_PRIVATE_KEY:
         required: true
@@ -66,7 +74,7 @@ permissions: {}
 
 jobs:
   auto-merge:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner_label }}
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/_release-please.yml
+++ b/.github/workflows/_release-please.yml
@@ -53,6 +53,14 @@ on:
           to use the quiet-window batching flow instead.
         type: boolean
         default: true
+      runner_label:
+        description: >-
+          GitHub Actions runner label. Defaults to ubuntu-latest. Pass a
+          RunsOn label (see runs-on.com/configuration/job-labels) to opt
+          the calling repo into self-hosted runners.
+        type: string
+        required: false
+        default: ubuntu-latest
     secrets:
       GH_APP_PRIVATE_KEY:
         required: true
@@ -67,7 +75,7 @@ permissions: {}
 
 jobs:
   release-please:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner_label }}
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/_retrigger-pr-checks.yml
+++ b/.github/workflows/_retrigger-pr-checks.yml
@@ -20,6 +20,15 @@ name: _retrigger-pr-checks
 
 on:
   workflow_call:
+    inputs:
+      runner_label:
+        description: >-
+          GitHub Actions runner label. Defaults to ubuntu-latest. Pass a
+          RunsOn label (see runs-on.com/configuration/job-labels) to opt
+          the calling repo into self-hosted runners.
+        type: string
+        required: false
+        default: ubuntu-latest
     secrets:
       GH_APP_PRIVATE_KEY:
         required: true
@@ -31,7 +40,7 @@ permissions: {}
 jobs:
   retrigger:
     name: Retrigger Missing CI Gate
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner_label }}
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
## Summary

- Threads an optional `runner_label` input (default `ubuntu-latest`) through every reusable workflow under `.github/workflows/_*.yml`.
- Calling repos opt into self-hosted RunsOn runners by passing a v3 label string; **no behavior change for any existing caller** because the default stays `ubuntu-latest`.
- Touched: `_ci-gate.yml` (also forwards to its children), `_markdown-lint.yml`, `_file-size.yml`, `_osv-scan.yml`, `_python-security.yml`, `_release-please.yml`, `_release-please-auto-merge.yml`, `_gh-aw-pin-refresh.yml`, `_cribl-pack-validate.yml`, `_retrigger-pr-checks.yml`.
- Already had it: `_nix-validate.yml` (#296).
- Intentionally skipped: `_nix-build.yml` (macos-latest), `_copilot-setup-steps.yml` (deprecated, `if: false`).

Companion PRs in flight:
- JacobPEvans/terraform-runs-on#60 — migration guide.
- JacobPEvans/nix-darwin#1104 and JacobPEvans/nix-ai#783 — consumers that now pass `runner_label`.
- JacobPEvans/claude-code-plugins#308 and JacobPEvans/ai-assistant-instructions#638 — docs / skill / rule.

## Test plan

- [ ] CI passes on this PR (every reusable workflow's own consumer still resolves with default `ubuntu-latest`).
- [ ] Once merged, watch JacobPEvans/nix-darwin#1104 and JacobPEvans/nix-ai#783 PR runs to confirm `runner_label` actually routes the job to RunsOn (look for `RUNS_ON_VERSION=v3.x.x` in the `Set up runner` group).