### PR TITLE
chore(renovate): tidy preset defaults

### DIFF
--- a/renovate-presets.json
+++ b/renovate-presets.json
@@ -27,7 +27,6 @@
     ".github/aw/**"
   ],
   "minimumReleaseAge": "3 days",
-  "timezone": "America/Chicago",
   "vulnerabilityAlerts": {
     "enabled": true,
     "labels": ["type:security"],


### PR DESCRIPTION
## Summary

Remove an unused field from the org-wide Renovate preset. Defaults are sufficient.

## Test plan

- [x] renovate-presets.json is valid JSON
- [ ] Downstream repos extending this preset continue to evaluate Renovate runs correctly

Assisted-by: Claude <noreply@anthropic.com>