### PR TITLE
fix(renovate): bump Python `>=` lower bounds on every release

### DIFF
--- a/renovate-presets.json
+++ b/renovate-presets.json
@@ -228,6 +228,11 @@
       "matchUpdateTypes": ["minor", "patch"],
       "automerge": true,
       "schedule": ["after 7am on Monday", "after 7am on Thursday"]
+    },
+    {
+      "description": "Bump Python `>=` lower bounds so they track the latest released version. Without this, Renovate's default `auto` strategy (= `replace` for pep621/pip_requirements) leaves `pyarrow>=17.0.0` untouched forever even when 24.x is current — the existing range already satisfies the new version, so `replace` no-ops. Setting `bump` forces the lower bound to move with each release, keeping security floors current. Mirrors the `rangeStrategy: bump` already used inside `vulnerabilityAlerts` so routine and CVE-driven bumps behave identically.",
+      "matchManagers": ["pep621", "pip_requirements", "pip_setup", "poetry", "pipenv"],
+      "rangeStrategy": "bump"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Closes the gap that let `pyarrow>=17.0.0` sit untouched for months while pyarrow shipped through 18.x → 24.x. Surfaced by mlx-benchmarks#55, where the unfixable-CVE PYSEC-2026-113 (CVSS 7.0 High, fixed in 23.0.1) only became visible when OSV started flagging it on every PR.

## Root cause

Renovate's default `rangeStrategy: auto` maps to `replace` for `pep621` and `pip_requirements`. `replace` only bumps a constraint when the new version falls **outside** the existing range. Since `>=17.0.0` is satisfied by 18, 19, 20, 21, 22, 23, **and** 24, replace no-ops indefinitely. The lower bound ages out of sync with the actual installed (lockfile) version and becomes a stale security floor for downstream consumers of the library.

The `vulnerabilityAlerts` block already sets `rangeStrategy: bump` for CVE-driven updates. This PR mirrors that behaviour for routine releases too, on a focused set of Python managers.

## Change

One new packageRule appended to `renovate-presets.json`:

```json
{
  "matchManagers": ["pep621", "pip_requirements", "pip_setup", "poetry", "pipenv"],
  "rangeStrategy": "bump"
}
```

`bump` forces the lower bound to track the latest release even when the existing range still satisfies it.

## Why this scope

| Manager | Default behaviour | Need `bump`? |
| --- | --- | --- |
| `pep621` / `pip_requirements` / `pip_setup` / `poetry` / `pipenv` | `>=X` ranges no-op forever | **Yes** — this PR |
| `npm` | `^X.Y.Z` caps at next major; majors are outside-range so `replace` bumps them | No |
| `cargo` | `^X.Y.Z` / `~X.Y.Z` behave like npm | No |
| `terraform` | `>= 1.0` has the same pathology | Could extend later if it surfaces |
| `pre-commit` | Pinned `rev:` tags get exact-match bumps | No |

## Impact

At the time of this PR, every workspace repo consuming the preset has stale `>=` constraints:

| Repo | `>=` pins |
| --- | --- |
| `mlx-benchmarks` | 18 |
| `nix-ai/orchestrator` | 16 |
| `python-template` | 11 |
| `nix-ai/mlx-server` | 3 |
| `claude-code-plugins/content-guards` | 2 |

After this PR lands, Renovate will (on the next scheduled run — Mon/Thu 7am per the existing Python schedule rule) open PRs to bring each of those constraints current. Examples that are demonstrably behind today:

| Package | Current pin in mlx-benchmarks | Latest on PyPI |
| --- | --- | --- |
| `pyarrow` | `>=17.0.0` (fixed in mlx-benchmarks#55 to 23.0.1) | 24.0.0 |
| `pandas` | `>=2.0` | 3.0.3 |
| `psutil` | `>=5.9` | 7.2.2 |
| `pytest-cov` | `>=5.0` | 7.1.0 |
| `openai` | `>=1.0.0` | 2.38.0 |
| `mypy` | `>=1.11` | 2.1.0 |
| `huggingface-hub` | `>=0.23` | 1.16.1 |
| `pytest` | `>=8.3` | 9.0.3 |
| `pre-commit` | `>=3.8` | 4.6.0 |
| `ruff` | `>=0.6.9` | 0.15.14 |

Bumps will auto-merge for minor/patch (per the existing `pep621/pip_requirements` auto-merge rule) and human-review for majors (per the `Never auto-merge major updates` rule already in the preset).

## Test plan

- [x] `jq empty renovate-presets.json` passes
- [x] Pre-commit clean on the changed file
- [ ] After merge: wait for Renovate's next Mon/Thu run, watch for the wave of stale-pin bump PRs across consumer repos
- [ ] Verify a Python `>=` bump PR opens against this repo or another consumer within 48h

## Out of scope

- The `fix/renovate-vuln-bump` branch (unpushed WIP that removes `dependencyDashboard`, `osvVulnerabilityAlerts`, and several settings). That refactor is broader and should be discussed separately.
- Terraform `>=` constraint bumping. Same pathology but no concrete example pinned today.
- Bumping the consumer-repo pyproject files manually. Per the original request, the only manual fix is this one renovate rule; everything else flows from Renovate after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)