### PR TITLE
fix(renovate): update semver regex and pep723 pattern fix

### DIFF
--- a/renovate-presets.json
+++ b/renovate-presets.json
@@ -16,11 +16,17 @@
   ],
   "minimumReleaseAge": "3 days",
   "timezone": "America/Chicago",
+  "rangeStrategy": "update-lockfile",
+  "pep723": {
+    "managerFilePatterns": ["/\\.py$/"]
+  },
   "vulnerabilityAlerts": {
     "enabled": true,
     "labels": ["type:security"],
     "automerge": true,
-    "minimumReleaseAge": "0 days"
+    "minimumReleaseAge": "0 days",
+    "rangeStrategy": "bump",
+    "vulnerabilityFixStrategy": "highest"
   },
   "lockFileMaintenance": {
     "enabled": true,
@@ -42,8 +48,8 @@
       "customType": "regex",
       "fileMatch": ["\\.nix$"],
       "matchStrings": [
-        "\"(?<depName>@[a-zA-Z0-9-]+/[a-zA-Z0-9][a-zA-Z0-9._-]*)@(?<currentValue>[\\d][^\\s\"]*)\"",
-        "bunx\\s+--bun\\s+(?<depName>(?:@[^@/]+\\/)?[^@\\s]+)@(?<currentValue>[\\d][^\\s\"']*)"
+        "\"(?<depName>@[a-z0-9][a-z0-9-]*/[a-z0-9][a-z0-9._-]*)@(?<currentValue>\\d+(?:\\.\\d+)*(?:[._-]?(?:a|b|rc|alpha|beta|dev|post)\\d*)?(?:\\+[A-Za-z0-9.]+)?)\"",
+        "bunx\\s+--bun\\s+(?<depName>(?:@[^@/]+\\/)?[^@\\s]+)@(?<currentValue>\\d+(?:\\.\\d+)*(?:[._-]?(?:a|b|rc|alpha|beta|dev|post)\\d*)?(?:\\+[A-Za-z0-9.]+)?)"
       ],
       "datasourceTemplate": "npm"
     },
@@ -52,11 +58,7 @@
       "customType": "regex",
       "fileMatch": ["\\.nix$"],
       "matchStrings": [
-        "uvx\\s+--from\\s+\"(?<depName>[a-zA-Z0-9][a-zA-Z0-9._-]*)(?:\\[[^\\]]+\\])?==(?<currentValue>[\\d][^\\s\"]*)\"",
-        "uv\\s+run[^\"]*--with\\s+\"(?<depName>[a-zA-Z0-9][a-zA-Z0-9._-]*)(?:\\[[^\\]]+\\])?==(?<currentValue>[\\d][^\\s\"]*)\"",
-        "\"--from\"\\r?\\n\\s+\"(?<depName>[a-zA-Z0-9][a-zA-Z0-9._-]*)(?:\\[[^\\]]+\\])?==(?<currentValue>[\\d][^\\s\"]*)\"",
-        "\"--with\"\\r?\\n\\s+\"(?<depName>[a-zA-Z0-9][a-zA-Z0-9._-]*)(?:\\[[^\\]]+\\])?==(?<currentValue>[\\d][^\\s\"]*)\"",
-        "\\buv\\S*\\s+tool\\s+install\\s+\"(?<depName>[a-zA-Z0-9][a-zA-Z0-9._-]*)(?:\\[[^\\]]+\\])?==(?<currentValue>[\\d][^\\s\"]*)\""
+        "(?:uvx\\s+--from\\s+|uv\\s+run[^\"]*--with\\s+|\\buv\\S*\\s+tool\\s+install\\s+|\"--(?:from|with)\"\\r?\\n\\s+)\"(?<depName>[A-Za-z0-9][A-Za-z0-9._-]*)(?:\\[[^\\]]+\\])?==(?<currentValue>\\d+(?:\\.\\d+)*(?:[._-]?(?:a|b|rc|alpha|beta|dev|post)\\d*)?(?:\\+[A-Za-z0-9.]+)?)\""
       ],
       "datasourceTemplate": "pypi"
     },
@@ -65,7 +67,7 @@
       "customType": "regex",
       "fileMatch": ["\\.github/workflows/.*\\.ya?ml$"],
       "matchStrings": [
-        "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)[\\r\\n]+[\\s\\S]*?\\bnpx\\b\\s+(?:--yes\\s+|-y\\s+)?\\S+@(?<currentValue>[^\\s\"']+)"
+        "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)[\\r\\n]+[\\s\\S]*?\\bnpx\\b\\s+(?:--yes\\s+|-y\\s+)?\\S+@(?<currentValue>\\d+(?:\\.\\d+)*(?:[._-]?(?:a|b|rc|alpha|beta|dev|post)\\d*)?(?:\\+[A-Za-z0-9.]+)?)"
       ]
     }
   ],

--- a/renovate-presets.json
+++ b/renovate-presets.json
@@ -16,9 +16,8 @@
   ],
   "minimumReleaseAge": "3 days",
   "timezone": "America/Chicago",
-  "rangeStrategy": "update-lockfile",
   "pep723": {
-    "managerFilePatterns": ["/\\.py$/"]
+    "managerFilePatterns": ["\\.py$"]
   },
   "vulnerabilityAlerts": {
     "enabled": true,
@@ -48,8 +47,8 @@
       "customType": "regex",
       "fileMatch": ["\\.nix$"],
       "matchStrings": [
-        "\"(?<depName>@[a-z0-9][a-z0-9-]*/[a-z0-9][a-z0-9._-]*)@(?<currentValue>\\d+(?:\\.\\d+)*(?:[._-]?(?:a|b|rc|alpha|beta|dev|post)\\d*)?(?:\\+[A-Za-z0-9.]+)?)\"",
-        "bunx\\s+--bun\\s+(?<depName>(?:@[^@/]+\\/)?[^@\\s]+)@(?<currentValue>\\d+(?:\\.\\d+)*(?:[._-]?(?:a|b|rc|alpha|beta|dev|post)\\d*)?(?:\\+[A-Za-z0-9.]+)?)"
+        "\"(?<depName>@[a-z0-9][a-z0-9-]*/[a-z0-9][a-z0-9._-]*)@(?<currentValue>\\d+(?:\\.\\d+)*(?:-[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?(?:\\+[A-Za-z0-9.]+)?)\"",
+        "bunx\\s+--bun\\s+(?<depName>(?:@[^@/]+\\/)?[^@\\s]+)@(?<currentValue>\\d+(?:\\.\\d+)*(?:-[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?(?:\\+[A-Za-z0-9.]+)?)"
       ],
       "datasourceTemplate": "npm"
     },
@@ -67,7 +66,7 @@
       "customType": "regex",
       "fileMatch": ["\\.github/workflows/.*\\.ya?ml$"],
       "matchStrings": [
-        "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)[\\r\\n]+[\\s\\S]*?\\bnpx\\b\\s+(?:--yes\\s+|-y\\s+)?\\S+@(?<currentValue>\\d+(?:\\.\\d+)*(?:[._-]?(?:a|b|rc|alpha|beta|dev|post)\\d*)?(?:\\+[A-Za-z0-9.]+)?)"
+        "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)[\\r\\n]+[\\s\\S]*?\\bnpx\\b\\s+(?:--yes\\s+|-y\\s+)?\\S+@(?<currentValue>\\d+(?:\\.\\d+)*(?:-[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?(?:\\+[A-Za-z0-9.]+)?)"
       ]
     }
   ],


### PR DESCRIPTION
## Summary

Continues work from the closed PR #248.

- Updates custom npm/npx `matchStrings` regex to use proper semver `(-...)` pre-release separator instead of `[._-]?`
- Removes leading slash from `pep723.managerFilePatterns` (Renovate expects a plain glob, not a regex-anchored pattern)
- Removes `rangeStrategy: "update-lockfile"` (covered by package-rule defaults)

## Test plan
- [ ] Renovate dry-run produces no unexpected changes
- [ ] Existing vulnerability alerts still surface correct upgrade PRs