### PR TITLE
fix(release-please): tolerate label-application race

### DIFF
--- a/.github/workflows/_release-please.yml
+++ b/.github/workflows/_release-please.yml
@@ -72,8 +72,15 @@ jobs:
           permission-pull-requests: write
           permission-issues: write
 
+      # `continue-on-error` tolerates the upstream label-application race:
+      # release-please-action opens the PR successfully, then immediately tries
+      # to apply `autorelease: pending` via GraphQL — but the PR's global node ID
+      # hasn't propagated yet, so GitHub returns "Could not resolve to a node".
+      # The PR is still created and the downstream `Find release PR number` step
+      # discovers it via REST, so a label-only failure should not fail the job.
       - uses: googleapis/release-please-action@v5
         id: release
+        continue-on-error: true
         with:
           token: ${{ steps.app-token.outputs.token }}
           manifest-file: .release-please-manifest.json

--- a/.github/workflows/_release-please.yml
+++ b/.github/workflows/_release-please.yml
@@ -96,6 +96,12 @@ jobs:
           PR_NUMBER=$(gh pr list --head "release-please--branches--${BASE_BRANCH}" --json number --jq '.[0].number // empty')
           echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
 
+      - name: Re-fail on genuine release-please error
+        if: "!cancelled() && steps.release.outcome == 'failure' && steps.find-pr.outputs.number == ''"
+        run: |
+          echo "::error::release-please-action failed and no release PR was found via REST. This is a genuine failure (auth/config/API error), not a transient label-application race."
+          exit 1
+
       # Disable+re-enable handles RC3 (stale auto-merge queue: PR is CLEAN with
       # auto-merge enabled but GitHub never executes the merge). The retry loop
       # handles RC2 (transient GraphQL errors from `gh pr merge --auto`).


### PR DESCRIPTION
## Summary

- Adds `continue-on-error: true` to the label-application step to tolerate a race condition where the PR is not yet visible when the label workflow fires
- Re-fails on genuine errors when no PR is found (distinguishes the race from a real failure)

## Test plan
- [ ] Release-please runs without spurious failures when PR is created and labelled concurrently
- [ ] Genuine errors still surface (not silently swallowed)