### PR TITLE
docs(security): publisher-agnostic dependency model

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,56 +11,23 @@ For critical vulnerabilities affecting multiple repositories, report to the
 
 ## Dependency Trust
 
-Automated dependency updates use Renovate via this repo's presets
-([`renovate-presets.json`](renovate-presets.json) + [`renovate-grouping.json`](renovate-grouping.json)),
-which are a thin shim inheriting [dryvist/.github](https://github.com/dryvist/.github)'s
-master policy — the single source of truth for Renovate policy across every
-dryvist AND JacobPEvans repo. Minor/patch updates auto-merge
-publisher-agnostically; trust tiers gate only majors and PR-creation cadence.
-Canonical, fuller documentation:
-[docs.jacobpevans.com/infrastructure/cicd/dependency-automation](https://docs.jacobpevans.com/infrastructure/cicd/dependency-automation).
+This repo's `renovate-presets.json` is a thin shim inheriting Renovate policy
+from [dryvist/.github](https://github.com/dryvist/.github) — the single
+source of truth across all dryvist and JacobPEvans repositories. For the
+trust-tier table, allowlist, and exact config, see dryvist/.github's
+[`renovate-presets.json`](https://github.com/dryvist/.github/blob/main/renovate-presets.json)
+and [`SECURITY.md`](https://github.com/dryvist/.github/blob/main/SECURITY.md),
+or [docs.jacobpevans.com/infrastructure/cicd/dependency-automation](https://docs.jacobpevans.com/infrastructure/cicd/dependency-automation).
 
-| Tier | Scope | PR-creation cadence | Majors |
-| --- | --- | --- | --- |
-| **First-party** | `dryvist/**`, `JacobPEvans/**`, `JacobPEvans-personal/**` | at any time | auto-merge immediately, incl. major |
-| **Trusted** | curated ~50-org allowlist | twice-weekly (Mon/Thu) | never auto-merge; 3-day review PR (`dep:review`) |
-| **Untrusted** | all other external deps | weekly (Mon) | never auto-merge; held 30 days for review |
-| **Security / CVE** | any vulnerability alert | immediate (0-day PR) | minor/patch auto-merges fast; a security major still opens for review |
+In short: minor/patch updates auto-merge publisher-agnostically (any package,
+any ecosystem) after a 3-day stabilization window and green CI. Majors never
+auto-merge except first-party (`dryvist/**`, `JacobPEvans/**`,
+`JacobPEvans-personal/**`); a security-triggered major still opens for review
+like any other major.
 
-**Minor/patch updates auto-merge publisher-agnostically** — any package, any
-ecosystem, any publisher — after a 3-day stabilization window and green CI.
-Trust tiers do not gate minor/patch; they gate only majors and PR-creation
-cadence.
-
-- **First-party** — our own published packages. release-please cuts and
-  auto-merges every release, so changes propagate to consumers at once
-  (0-day auto-merge, all update types including major).
-- **Trusted** — the curated org allowlist in `renovate-presets.json` (actions,
-  google, github, hashicorp, astral-sh, NixOS, …). Trust here shortens the
-  major-default 30-day hold to a 3-day review PR (`dep:review` label); it has
-  no effect on minor/patch, which auto-merges the same way for every tier.
-- **Untrusted** — everything else, including Nix flake inputs and Python
-  packages that aren't on the trusted allowlist. Minor/patch still
-  auto-merges through the same publisher-agnostic rule; the only differences
-  are a weekly (vs twice-weekly) PR-creation cadence and the full 30-day
-  hold before a major opens for review.
-- **Majors never auto-merge except first-party** — a compatible-looking
-  version is not a compatible API. First-party majors auto-merge
-  immediately; trusted-org majors open a 3-day review PR; every other major
-  is held 30 days.
-- **Security / CVE** — `vulnerabilityAlerts` surfaces a 0-day PR
-  immediately, bypassing the normal schedule. The auto-merge decision then
-  falls to the same packageRules as any other update: a security minor/patch
-  inherits the broad rule's fast auto-merge, while a security major still
-  opens for review like any other major.
-- **Supply-chain safety** for the broad auto-merge set is the deterministic
-  `dependency-review` job (`actions/dependency-review-action`) inside the
-  required Merge Gate on public repos. The `ai-workflows` dependency
-  reviewer is advisory only — it labels findings for human follow-up but
-  does not gate or block auto-merge.
-- Renovate merges directly via its own API rather than GitHub's native
-  auto-merge queue (`platformAutomerge: false`) — the native queue has a
-  known bug where PRs pass all checks but GitHub never executes the merge.
+Supply-chain scanning via a deterministic `dependency-review` job in a
+required Merge Gate is the canonical posture upstream — not yet present in
+this repo's own local gate.
 
 GitHub Actions from untrusted orgs are pinned to SHA digests, not tags;
 first-party self-references ride `@main` (see Version Pinning below).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,17 +9,61 @@ on the affected repository. Do not open a public issue for security vulnerabilit
 For critical vulnerabilities affecting multiple repositories, report to the
 [.github repository](https://github.com/JacobPEvans/.github/security/advisories/new).
 
-## Dependency Trust Tiers
+## Dependency Trust
 
-All automated dependency updates follow a tiered trust model enforced by
-[Renovate](https://docs.renovatebot.com/) via `renovate-presets.json`:
+Automated dependency updates use Renovate via this repo's presets
+([`renovate-presets.json`](renovate-presets.json) + [`renovate-grouping.json`](renovate-grouping.json)),
+which are a thin shim inheriting [dryvist/.github](https://github.com/dryvist/.github)'s
+master policy — the single source of truth for Renovate policy across every
+dryvist AND JacobPEvans repo. Minor/patch updates auto-merge
+publisher-agnostically; trust tiers gate only majors and PR-creation cadence.
+Canonical, fuller documentation:
+[docs.jacobpevans.com/infrastructure/cicd/dependency-automation](https://docs.jacobpevans.com/infrastructure/cicd/dependency-automation).
 
-| Tier | Scope | Stabilization | Auto-merge | Rationale |
-| ------ | ------- | --------------- | ------------ | ----------- |
-| **Always Trusted** | `JacobPEvans/**` (self-owned repos) | 0 days | Yes, CI-gated | Full code review and commit signing control |
-| **Trusted, Wait** | GitHub Actions, Terraform, PyPI, pre-commit hooks | 3 days | Minor/patch auto; major manual | Established orgs; strong security posture |
-| **Trusted Nix** | `NixOS/*`, `nix-community/*`, `cachix/*`, `DeterminateSystems/*` | 3 days | Yes, CI-gated | Community-monitored, commit-pinned (immutable) |
-| **Default** | All other external dependencies | 3 days | No | Requires manual review before merge |
+| Tier | Scope | PR-creation cadence | Majors |
+| --- | --- | --- | --- |
+| **First-party** | `dryvist/**`, `JacobPEvans/**`, `JacobPEvans-personal/**` | at any time | auto-merge immediately, incl. major |
+| **Trusted** | curated ~50-org allowlist | twice-weekly (Mon/Thu) | never auto-merge; 3-day review PR (`dep:review`) |
+| **Untrusted** | all other external deps | weekly (Mon) | never auto-merge; held 30 days for review |
+| **Security / CVE** | any vulnerability alert | immediate (0-day PR) | minor/patch auto-merges fast; a security major still opens for review |
+
+**Minor/patch updates auto-merge publisher-agnostically** — any package, any
+ecosystem, any publisher — after a 3-day stabilization window and green CI.
+Trust tiers do not gate minor/patch; they gate only majors and PR-creation
+cadence.
+
+- **First-party** — our own published packages. release-please cuts and
+  auto-merges every release, so changes propagate to consumers at once
+  (0-day auto-merge, all update types including major).
+- **Trusted** — the curated org allowlist in `renovate-presets.json` (actions,
+  google, github, hashicorp, astral-sh, NixOS, …). Trust here shortens the
+  major-default 30-day hold to a 3-day review PR (`dep:review` label); it has
+  no effect on minor/patch, which auto-merges the same way for every tier.
+- **Untrusted** — everything else, including Nix flake inputs and Python
+  packages that aren't on the trusted allowlist. Minor/patch still
+  auto-merges through the same publisher-agnostic rule; the only differences
+  are a weekly (vs twice-weekly) PR-creation cadence and the full 30-day
+  hold before a major opens for review.
+- **Majors never auto-merge except first-party** — a compatible-looking
+  version is not a compatible API. First-party majors auto-merge
+  immediately; trusted-org majors open a 3-day review PR; every other major
+  is held 30 days.
+- **Security / CVE** — `vulnerabilityAlerts` surfaces a 0-day PR
+  immediately, bypassing the normal schedule. The auto-merge decision then
+  falls to the same packageRules as any other update: a security minor/patch
+  inherits the broad rule's fast auto-merge, while a security major still
+  opens for review like any other major.
+- **Supply-chain safety** for the broad auto-merge set is the deterministic
+  `dependency-review` job (`actions/dependency-review-action`) inside the
+  required Merge Gate on public repos. The `ai-workflows` dependency
+  reviewer is advisory only — it labels findings for human follow-up but
+  does not gate or block auto-merge.
+- Renovate merges directly via its own API rather than GitHub's native
+  auto-merge queue (`platformAutomerge: false`) — the native queue has a
+  known bug where PRs pass all checks but GitHub never executes the merge.
+
+GitHub Actions from untrusted orgs are pinned to SHA digests, not tags;
+first-party self-references ride `@main` (see Version Pinning below).
 
 ### Version Pinning Strategy
 
@@ -29,7 +73,7 @@ All automated dependency updates follow a tiered trust model enforced by
 | Trusted GitHub Actions | Semantic version tags (e.g., `@v6`) |
 | External/untrusted GitHub Actions | SHA commit hash pins |
 | Nix flake inputs | Branch-pinned to stable releases (e.g., `nixpkgs-25.11-darwin`) |
-| Python packages (pyproject.toml) | Lower-bound with `>=`, managed by Renovate with 3-day soak |
+| Python packages (pyproject.toml) | Lower-bound with `>=`; publisher-agnostic minor/patch auto-merge like every other ecosystem |
 | Python tool installs (uv) | Exact pin with `==`, managed by Renovate custom regex |
 
 ## Dependency Update Vectors


### PR DESCRIPTION
Reconciles the Dependency Trust section to the canonical publisher-agnostic model (matches dryvist/.github SECURITY.md): minor/patch auto-merge regardless of publisher after a 3-day stabilization + green CI; trust tiers gate only majors and PR-creation cadence; first-party is immediate; a security major opens for review. Part of the org-wide dependency-automation documentation reconciliation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)