### PR TITLE
fix(gate): called jobs must never exceed the standard caller permission grant

### DIFF
--- a/.github/workflows/_ci-gate.yml
+++ b/.github/workflows/_ci-gate.yml
@@ -178,15 +178,19 @@ jobs:
     name: Dependency Review
     if: ${{ inputs.dependency_review && github.event_name == 'pull_request' && github.event.repository.private == false }}
     runs-on: ${{ inputs.runner_label }}
+    # contents:read ONLY — a called workflow's job may never request more than
+    # the caller granted, or the whole run dies at graph validation
+    # (startup_failure) before any job starts. `pull-requests: write` (for
+    # comment-summary-in-pr) exceeded the standard caller grant and broke
+    # every consumer's gate; failure detail lives in the check-run output
+    # instead of a PR comment.
     permissions:
       contents: read
-      pull-requests: write
     steps:
       - uses: actions/checkout@v6
       - uses: actions/dependency-review-action@v5
         with:
           fail-on-severity: moderate
-          comment-summary-in-pr: on-failure
 
   # ============================================================================
   # WATCHDOG


### PR DESCRIPTION
Mirrors dryvist/.github#81: the `dependency-review` job requested `pull-requests: write`, which exceeds the standard caller grant (`contents: read`, `pull-requests: read`, `actions: write`). GitHub Actions validates called-workflow permissions at graph compile time, so any caller granting less dies with `startup_failure` before a single job runs — even when the job's `if:` is false. Scopes the job to `contents: read` only and drops the PR comment summary (failure detail stays in the check-run output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CB5heppQHhv8xE1XWeeFVA