### PR TITLE
docs(auth): fix stale aws-vault entry for terraform-proxmox

### DIFF
--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -18,10 +18,16 @@ Cross-repository reference for how credentials are managed across the JacobPEvan
 
 ### aws-vault
 
-- **Used by**: terraform-aws, terraform-proxmox, terraform-aws-bedrock
+- **Used by**: terraform-aws, terraform-aws-bedrock
 - **Purpose**: AWS credential management with MFA/session tokens
 - **Access**: Via `aws-vault exec <profile> --` prefix
-- **Detailed guide**: See terraform-proxmox `docs/aws-vault-terraform.md`
+
+### OpenBao (AWS secrets engine)
+
+- **Used by**: terraform-proxmox
+- **Purpose**: AWS credential management for automation and AI agents — a dynamic secrets engine brokers short-lived STS sessions,
+  replacing the retired static aws-vault base key for this repo
+- **Access**: Terrakube workspace JWT identity (CI/plan/apply); local/agent access via an AWS `credential_process` profile backed by an OpenBao AppRole
 
 ### SOPS/age
 


### PR DESCRIPTION
## Summary

`docs/AUTHENTICATION.md` still listed `terraform-proxmox` under the `aws-vault` provider and linked to a `docs/aws-vault-terraform.md` detail page in that repo — that file no longer exists (dead link). `terraform-proxmox` has migrated its AWS access off the static aws-vault base key to a Terrakube + OpenBao AWS secrets engine broker.

- `aws-vault` entry keeps its still-accurate repos (`terraform-aws`, `terraform-aws-bedrock` — verified still on the aws-vault path).
- `terraform-proxmox` gets its own `OpenBao (AWS secrets engine)` entry describing the current mechanism (Terrakube workspace JWT for CI, `credential_process` + OpenBao AppRole for local/agent access).

## Verification

- `pre-commit run --files docs/AUTHENTICATION.md` — markdownlint, markdown-link-check, and file-size checks all pass.

## Test plan

- [ ] Confirm no other repo in this registry references the now-removed `docs/aws-vault-terraform.md` path.